### PR TITLE
Delayed re-queuing using gateway support (when supported)

### DIFF
--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/HeaderNames.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/HeaderNames.cs
@@ -59,5 +59,13 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
         /// The handle d_ count{CC2D43FA-BBC4-448A-9D0B-7B57ADF2655C}
         /// </summary>
         public const string HANDLED_COUNT = "HandledCount";
+        /// <summary>
+        /// The milliseconds to delay the message by (requires plugin rabbitmq_delayed_message_exchange)
+        /// </summary>
+        public const string DELAY_MILLISECONDS = "x-delay";
+        /// <summary>
+        /// The milliseconds the message was instructed to be delayed for (sent as negative) (requires plugin rabbitmq_delayed_message_exchange)
+        /// </summary>
+        public const string DELAYED_MILLISECONDS = "x-delay";
     }
 }

--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/MessageGateway.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/MessageGateway.cs
@@ -134,13 +134,9 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
 
                 Logger.DebugFormat("RMQMessagingGateway: Declaring exchange {0} on connection {1}", Configuration.Exchange.Name, Configuration.AMPQUri.GetSanitizedUri());
 
-                DeclareExchange(Channel, Configuration);
+                //desired state configuration of the exchange
+                Channel.DeclareExchangeForConfiguration(Configuration);
             }
-        }
-
-        private void DeclareExchange(IModel channel, RMQMessagingGatewayConfigurationSection configuration)        {
-            //desired state configuration of the exchange
-            channel.ExchangeDeclare(configuration.Exchange.Name, ExchangeType.Direct, configuration.Exchange.Durable);
         }
 
         /// <summary>

--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/MessageGateway.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/MessageGateway.cs
@@ -76,6 +76,8 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
             _circuitBreakerPolicy = connectionPolicyFactory.CircuitBreakerPolicy;
 
             _connectionFactory = new ConnectionFactory { Uri = Configuration.AMPQUri.Uri.ToString(), RequestedHeartbeat = 30 };
+
+            DelaySupported = (this is IAmAMessageGatewaySupportingDelay) && Configuration.Exchange.SupportDelay;
         }
 
         /// <summary>
@@ -92,6 +94,11 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
         /// The channel
         /// </summary>
         protected IModel Channel;
+
+        /// <summary>
+        /// Gets if the current provider configuration is able to support delayed delivery of messages.
+        /// </summary>
+        public bool DelaySupported { get; private set; }
 
         /// <summary>
         /// Connects the specified queue name.

--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/MessageGatewayHelper.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/MessageGatewayHelper.cs
@@ -1,0 +1,45 @@
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using RabbitMQ.Client;
+using paramore.brighter.commandprocessor.messaginggateway.rmq.MessagingGatewayConfiguration;
+
+namespace paramore.brighter.commandprocessor.messaginggateway.rmq
+{
+    public static class MessageGatewayHelper
+    {
+        internal static void DeclareExchangeForConfiguration(this IModel channel, RMQMessagingGatewayConfigurationSection configuration)
+        {
+            if (configuration.Exchange.SupportDelay)
+                channel.ExchangeDeclare(configuration.Exchange.Name, "x-delayed-message", configuration.Exchange.Durable, autoDelete: false, arguments: new Dictionary<string, object> { { "x-delayed-type", "direct" } });
+            else
+                channel.ExchangeDeclare(configuration.Exchange.Name, ExchangeType.Direct, configuration.Exchange.Durable);
+        }
+    }
+}

--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/MessagingGatewayConfiguration/RMQMessagingGatewayConfigurationSection.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/MessagingGatewayConfiguration/RMQMessagingGatewayConfigurationSection.cs
@@ -223,5 +223,17 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq.MessagingGatew
             get { return (bool)this["durable"]; }
             set { this["durable"] = value; }
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating if the declared <see cref="Exchange"/> support delayed messages.
+        /// (requires plugin rabbitmq_delayed_message_exchange)
+        /// </summary>
+        /// <value><c>true</c> if supporting; otherwise, <c>false</c>.</value>
+        [ConfigurationProperty("supportDelay", DefaultValue = false)]
+        public bool SupportDelay
+        {
+            get { return (bool)this["supportDelay"]; }
+            set { this["supportDelay"] = value; }
+        }
     }
 }

--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/Properties/AssemblyInfo.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/Properties/AssemblyInfo.cs
@@ -23,6 +23,7 @@ THE SOFTWARE. */
 #endregion
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -56,3 +57,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyInformationalVersion("2.0.1")]
 [assembly: AssemblyVersion("2.0.1.0")]
 [assembly: AssemblyFileVersion("2.0.*")]
+
+[assembly: InternalsVisibleTo("paramore.commandprocessor.tests")]

--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/RmqMessageConsumer.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/RmqMessageConsumer.cs
@@ -55,7 +55,7 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
     /// inter-process communication tasks from the server. It handles connection establishment, request reception and dispatching, 
     /// result sending, and error handling.
     /// </summary>
-    public class RmqMessageConsumer : MessageGateway, IAmAMessageConsumer
+    public class RmqMessageConsumer : MessageGateway, IAmAMessageConsumerSupportingDelay
     {
         private readonly string _queueName;
         private readonly string _routingKey;
@@ -125,12 +125,17 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
 
         public void Requeue(Message message)
         {
+            this.Requeue(message, 0);
+        }
+
+        public void Requeue(Message message, int delayMilliseconds)
+        {
             try
             {
                 EnsureChannel(_queueName);
                 var rmqMessagePublisher = new RmqMessagePublisher(Channel, Configuration.Exchange.Name);
-                Logger.DebugFormat("RmqMessageConsumer: Re-queueing message {0}", message.Id);
-                rmqMessagePublisher.PublishMessage(message);
+                Logger.DebugFormat("RmqMessageConsumer: Re-queueing message {0} with a delay of {1} milliseconds", message.Id, delayMilliseconds);
+                rmqMessagePublisher.PublishMessage(message, delayMilliseconds);
                 Reject(message, false);
             }
             catch (Exception exception)

--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/RmqMessagePublisher.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/RmqMessagePublisher.cs
@@ -39,7 +39,7 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
     /// </summary>
     public class RmqMessagePublisher
     {
-        private static string[] HeadersToReset = { HeaderNames.DELAY_MILLISECONDS };
+        private static string[] HeadersToReset = { HeaderNames.DELAY_MILLISECONDS, HeaderNames.MESSAGE_TYPE, HeaderNames.TOPIC, HeaderNames.HANDLED_COUNT };
 
         private readonly IModel _channel;
         private readonly string _exchangeName;

--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/paramore.brighter.commandprocessor.messaginggateway.rmq.csproj
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/paramore.brighter.commandprocessor.messaginggateway.rmq.csproj
@@ -54,6 +54,7 @@
     <Compile Include="HeaderNames.cs" />
     <Compile Include="HeaderResult.cs" />
     <Compile Include="MessageGatewayConnectionPool.cs" />
+    <Compile Include="MessageGatewayHelper.cs" />
     <Compile Include="MessagingGatewayConfiguration\RMQMessagingGatewayConfigurationSection.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="InputChannelfactory.cs" />

--- a/Brighter/paramore.brighter.commandprocessor.tests/AppConfig.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/AppConfig.cs
@@ -1,0 +1,65 @@
+﻿// Taken from http://stackoverflow.com/questions/6150644/change-default-app-config-at-runtime?answertab=votes#tab-top
+
+using System;
+using System.Configuration;
+using System.Linq;
+using System.Reflection;
+
+internal abstract class AppConfig : IDisposable
+{
+    public static AppConfig Change(string path)
+    {
+        return new ChangeAppConfig(path);
+    }
+
+    public abstract void Dispose();
+
+    private class ChangeAppConfig : AppConfig
+    {
+        private readonly string oldConfig =
+            AppDomain.CurrentDomain.GetData("APP_CONFIG_FILE").ToString();
+
+        private bool disposedValue;
+
+        public ChangeAppConfig(string path)
+        {
+            AppDomain.CurrentDomain.SetData("APP_CONFIG_FILE", path);
+            ResetConfigMechanism();
+        }
+
+        public override void Dispose()
+        {
+            if (!disposedValue)
+            {
+                AppDomain.CurrentDomain.SetData("APP_CONFIG_FILE", oldConfig);
+                ResetConfigMechanism();
+
+
+                disposedValue = true;
+            }
+            GC.SuppressFinalize(this);
+        }
+
+        private static void ResetConfigMechanism()
+        {
+            typeof(ConfigurationManager)
+                .GetField("s_initState", BindingFlags.NonPublic |
+                                         BindingFlags.Static)
+                .SetValue(null, 0);
+
+            typeof(ConfigurationManager)
+                .GetField("s_configSystem", BindingFlags.NonPublic |
+                                            BindingFlags.Static)
+                .SetValue(null, null);
+
+            typeof(ConfigurationManager)
+                .Assembly.GetTypes()
+                .Where(x => x.FullName ==
+                            "System.Configuration.ClientConfigPaths")
+                .First()
+                .GetField("s_current", BindingFlags.NonPublic |
+                                       BindingFlags.Static)
+                .SetValue(null, null);
+        }
+    }
+}

--- a/Brighter/paramore.brighter.commandprocessor.tests/app.with-delay.config
+++ b/Brighter/paramore.brighter.commandprocessor.tests/app.with-delay.config
@@ -1,0 +1,106 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <section name="rmqMessagingGateway" type="paramore.brighter.commandprocessor.messaginggateway.rmq.MessagingGatewayConfiguration.RMQMessagingGatewayConfigurationSection, paramore.brighter.commandprocessor.messaginggateway.rmq" allowLocation="true" allowDefinition="Everywhere" />
+    <section name="restMSMessagingGateway" type="paramore.brighter.commandprocessor.messaginggateway.restms.MessagingGatewayConfiguration.RestMSMessagingGatewayConfigurationSection, paramore.brighter.commandprocessor.messaginggateway.restms" allowLocation="true" allowDefinition="Everywhere" />
+    <section name="serviceActivatorConnections" type="paramore.brighter.serviceactivator.ServiceActivatorConfiguration.ServiceActivatorConfigurationSection, paramore.brighter.serviceactivator" allowLocation="true" allowDefinition="Everywhere" />
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
+    <!-- Other <section> and <sectionGroup> elements. -->
+  </configSections>
+  <connectionStrings>
+    <add name="MessageStore" connectionString="Url = http://localhost:8080" />
+  </connectionStrings>
+  <rmqMessagingGateway>
+    <amqpUri uri="amqp://guest:guest@localhost:5672/%2f" />
+    <exchange name="paramore.brighter.delayed-exchange" supportDelay="true" />
+  </rmqMessagingGateway>
+  <restMSMessagingGateway>
+    <restMS uri="http://localhost:3416/restms/domain/default" id="dh37fgj492je" user="Guest" key="wBgvhp1lZTr4Tb6K6+5OQa1bL9fxK7j8wBsepjqVNiQ=" timeout="2000" />
+    <feed name="test" type="Default" />
+  </restMSMessagingGateway>
+  <serviceActivatorConnections>
+    <connections>
+      <add connectionName="foo" channelName="mary" routingKey="bob" dataType="paramore.commandprocessor.tests.CommandProcessors.TestDoubles.MyEvent" noOfPerformers="1" timeOutInMilliseconds="200" requeueCount="-1" />
+      <add connectionName="bar" channelName="alice" routingKey="simon" dataType="paramore.commandprocessor.tests.CommandProcessors.TestDoubles.MyEvent" noOfPerformers="2" timeOutInMilliseconds="100" requeueCount="-1" />
+    </connections>
+  </serviceActivatorConnections>
+  <log4net debug="true">
+    <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
+      <layout type="log4net.Layout.PatternLayout">
+        <param name="ConversionPattern" value="%d [%t] %-5p %c [%x] - %m%n" />
+      </layout>
+    </appender>
+    <root>
+      <level value="DEBUG" />
+      <appender-ref ref="ConsoleAppender" />
+    </root>
+  </log4net>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.2.0.0" newVersion="3.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Raven.Abstractions" publicKeyToken="37f41c7f99471593" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.3.0" newVersion="5.6.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.3.0" newVersion="5.6.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.3.0" newVersion="5.6.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="xunit" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.9.2.1705" newVersion="1.9.2.1705" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Practices.Unity" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Hosting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Brighter/paramore.brighter.commandprocessor.tests/paramore.brighter.commandprocessor.tests.csproj
+++ b/Brighter/paramore.brighter.commandprocessor.tests/paramore.brighter.commandprocessor.tests.csproj
@@ -131,6 +131,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AppConfig.cs" />
     <Compile Include="CommandProcessors\PipelineTests.cs" />
     <Compile Include="CommandProcessors\CommandProcessorTests.cs" />
     <Compile Include="CommandProcessors\PipelineContextTests.cs" />
@@ -230,6 +231,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.with-delay.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="app.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Brighter/paramore.brighter.commandprocessor/IAmAMessageConsumer.cs
+++ b/Brighter/paramore.brighter.commandprocessor/IAmAMessageConsumer.cs
@@ -72,4 +72,14 @@ namespace paramore.brighter.commandprocessor
         /// <param name="message"></param>
         void Requeue(Message message);
     }
+
+    public interface IAmAMessageConsumerSupportingDelay : IAmAMessageConsumer
+    {
+        /// <summary>
+        /// Requeues the specified message.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="delayMilliseconds">Number of milliseconds to delay delivery of the message.</param>
+        void Requeue(Message message, int delayMilliseconds);
+    }
 }

--- a/Brighter/paramore.brighter.commandprocessor/IAmAMessageConsumer.cs
+++ b/Brighter/paramore.brighter.commandprocessor/IAmAMessageConsumer.cs
@@ -73,7 +73,7 @@ namespace paramore.brighter.commandprocessor
         void Requeue(Message message);
     }
 
-    public interface IAmAMessageConsumerSupportingDelay : IAmAMessageConsumer
+    public interface IAmAMessageConsumerSupportingDelay : IAmAMessageConsumer, IAmAMessageGatewaySupportingDelay
     {
         /// <summary>
         /// Requeues the specified message.

--- a/Brighter/paramore.brighter.commandprocessor/IAmAMessageGatewaySupportingDelay.cs
+++ b/Brighter/paramore.brighter.commandprocessor/IAmAMessageGatewaySupportingDelay.cs
@@ -1,0 +1,31 @@
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+public interface IAmAMessageGatewaySupportingDelay
+{
+    /// <summary>
+    /// Gets if the current provider configuration is able to support delayed delivery of messages.
+    /// </summary>
+    bool DelaySupported { get; }
+}

--- a/Brighter/paramore.brighter.commandprocessor/IAmAMessageProducer.cs
+++ b/Brighter/paramore.brighter.commandprocessor/IAmAMessageProducer.cs
@@ -60,4 +60,25 @@ namespace paramore.brighter.commandprocessor
         /// <returns>Task.</returns>
         Task Send(Message message);
     }
+
+    /// <summary>
+    /// Interface IAmAMessageProducerSupportingDelay
+    /// Abstracts away the Application Layer used to push messages onto a <a href="http://parlab.eecs.berkeley.edu/wiki/_media/patterns/taskqueue.pdf">Task Queue</a>
+    /// Usually clients do not need to instantiate as access is via an <see cref="IAmAChannel"/> derived class.
+    /// We provide the following default gateway applications
+    /// <list type="bullet">
+    /// <item>AMQP</item>
+    /// <item>RESTML</item>
+    /// </list>
+    /// </summary>
+    public interface IAmAMessageProducerSupportingDelay : IAmAMessageProducer
+    {
+        /// <summary>
+        /// Send the specified message with specified delay
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="delayMilliseconds">Number of milliseconds to delay delivery of the message.</param>
+        /// <returns>Task.</returns>
+        Task Send(Message message, int delayMilliseconds);
+    }
 }

--- a/Brighter/paramore.brighter.commandprocessor/IAmAMessageProducer.cs
+++ b/Brighter/paramore.brighter.commandprocessor/IAmAMessageProducer.cs
@@ -71,7 +71,7 @@ namespace paramore.brighter.commandprocessor
     /// <item>RESTML</item>
     /// </list>
     /// </summary>
-    public interface IAmAMessageProducerSupportingDelay : IAmAMessageProducer
+    public interface IAmAMessageProducerSupportingDelay : IAmAMessageProducer, IAmAMessageGatewaySupportingDelay
     {
         /// <summary>
         /// Send the specified message with specified delay

--- a/Brighter/paramore.brighter.commandprocessor/IAmAnInputChannel.cs
+++ b/Brighter/paramore.brighter.commandprocessor/IAmAnInputChannel.cs
@@ -69,7 +69,8 @@ namespace paramore.brighter.commandprocessor
         /// <summary>
         /// Requeues the specified message.
         /// </summary>
-        /// <param name="message"></param>
-        void Requeue(Message message);
+        /// <param name="message">The message.</param>
+        /// <param name="delayMilliseconds">Number of milliseconds to delay delivery of the message.</param>
+        void Requeue(Message message, int delayMilliseconds = 0);
     }
 }

--- a/Brighter/paramore.brighter.commandprocessor/InputChannel.cs
+++ b/Brighter/paramore.brighter.commandprocessor/InputChannel.cs
@@ -62,7 +62,7 @@ namespace paramore.brighter.commandprocessor
         {
             _queueName = queueName;
             _messageConsumer = messageConsumer;
-            _messageConsumerSupportsDelay = _messageConsumer is IAmAMessageConsumerSupportingDelay;
+            _messageConsumerSupportsDelay = _messageConsumer is IAmAMessageConsumerSupportingDelay && (_messageConsumer as IAmAMessageGatewaySupportingDelay).DelaySupported;
         }
 
         /// <summary>

--- a/Brighter/paramore.brighter.commandprocessor/InputChannel.cs
+++ b/Brighter/paramore.brighter.commandprocessor/InputChannel.cs
@@ -37,6 +37,7 @@ THE SOFTWARE. */
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading.Tasks;
 
 namespace paramore.brighter.commandprocessor
 {
@@ -50,6 +51,7 @@ namespace paramore.brighter.commandprocessor
         private readonly string _queueName;
         private readonly IAmAMessageConsumer _messageConsumer;
         private readonly ConcurrentQueue<Message> _queue = new ConcurrentQueue<Message>();
+        private readonly bool _messageConsumerSupportsDelay;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InputChannel"/> class.
@@ -60,6 +62,7 @@ namespace paramore.brighter.commandprocessor
         {
             _queueName = queueName;
             _messageConsumer = messageConsumer;
+            _messageConsumerSupportsDelay = _messageConsumer is IAmAMessageConsumerSupportingDelay;
         }
 
         /// <summary>
@@ -113,9 +116,16 @@ namespace paramore.brighter.commandprocessor
         /// Requeues the specified message.
         /// </summary>
         /// <param name="message"></param>
-        public void Requeue(Message message)
+        public void Requeue(Message message, int delayMilliseconds = 0)
         {
-            _messageConsumer.Requeue(message);
+            if (delayMilliseconds > 0 && !_messageConsumerSupportsDelay)
+                Task.Delay(delayMilliseconds).Wait();
+
+            if (_messageConsumerSupportsDelay)
+                (_messageConsumer as IAmAMessageConsumerSupportingDelay).Requeue(message, delayMilliseconds);
+            else
+                _messageConsumer.Requeue(message);
+
         }
 
         /// <summary>

--- a/Brighter/paramore.brighter.commandprocessor/MessageHeader.cs
+++ b/Brighter/paramore.brighter.commandprocessor/MessageHeader.cs
@@ -105,7 +105,10 @@ namespace paramore.brighter.commandprocessor
         /// Gets the number of times this message has been seen 
         /// </summary>
         public int HandledCount { get; private set; }
-        //intended for extended headers
+        /// <summary>
+        /// Gets the number of milliseconds the message was instructed to be delayed for
+        /// </summary>
+        public int DelayedMilliseconds { get; private set; }
 
         public MessageHeader()
         {
@@ -125,8 +128,8 @@ namespace paramore.brighter.commandprocessor
             Bag = new Dictionary<string, object>();
             TimeStamp = RoundToSeconds(DateTime.UtcNow);
             HandledCount = 0;
+            DelayedMilliseconds = 0;
         }
-
 
         public MessageHeader(Guid messageId, string topic, MessageType messageType, DateTime timeStamp)
             : this(messageId, topic, messageType)
@@ -134,10 +137,11 @@ namespace paramore.brighter.commandprocessor
             TimeStamp = RoundToSeconds(timeStamp);
         }
 
-        public MessageHeader(Guid messageId, string topic, MessageType messageType, DateTime timeStamp, int handledCount)
+        public MessageHeader(Guid messageId, string topic, MessageType messageType, DateTime timeStamp, int handledCount, int delayedMilliseconds)
             : this(messageId, topic, messageType, timeStamp)
         {
             HandledCount = handledCount;
+            DelayedMilliseconds = delayedMilliseconds;
         }
 
         //AMQP spec says:
@@ -157,7 +161,7 @@ namespace paramore.brighter.commandprocessor
         /// <returns>true if the current object is equal to the <paramref name="other" /> parameter; otherwise, false.</returns>
         public bool Equals(MessageHeader other)
         {
-            return Id == other.Id && Topic == other.Topic && MessageType == other.MessageType && TimeStamp == other.TimeStamp && HandledCount == other.HandledCount;
+            return Id == other.Id && Topic == other.Topic && MessageType == other.MessageType && TimeStamp == other.TimeStamp && HandledCount == other.HandledCount && DelayedMilliseconds == other.DelayedMilliseconds;
         }
 
         /// <summary>
@@ -186,6 +190,7 @@ namespace paramore.brighter.commandprocessor
                 hashCode = (hashCode * 397) ^ (int)MessageType;
                 hashCode = (hashCode * 397) ^ TimeStamp.GetHashCode();
                 hashCode = (hashCode * 397) ^ HandledCount.GetHashCode();
+                hashCode = (hashCode * 397) ^ DelayedMilliseconds.GetHashCode();
                 return hashCode;
             }
         }

--- a/Brighter/paramore.brighter.commandprocessor/paramore.brighter.commandprocessor.csproj
+++ b/Brighter/paramore.brighter.commandprocessor/paramore.brighter.commandprocessor.csproj
@@ -61,6 +61,7 @@
     <Compile Include="IAmAChannel.cs" />
     <Compile Include="IAmAChannelFactory.cs" />
     <Compile Include="IAmAMessageConsumerFactory.cs" />
+    <Compile Include="IAmAMessageGatewaySupportingDelay.cs" />
     <Compile Include="IAmAMessageMapperFactory.cs" />
     <Compile Include="IAmAnInputChannel.cs" />
     <Compile Include="IAmAnOutputChannel.cs" />

--- a/Brighter/paramore.brighter.serviceactivator/Connection.cs
+++ b/Brighter/paramore.brighter.serviceactivator/Connection.cs
@@ -72,7 +72,15 @@ namespace paramore.brighter.serviceactivator
         /// </summary>
         /// <value>The timeout in miliseconds.</value>
         public int TimeoutInMiliseconds { get; private set; }
+        /// <summary>
+        /// Gets or sets the requeue count.
+        /// </summary>
+        /// <value>The requeue count.</value>
         public int RequeueCount { get; private set; }
+        /// <summary>
+        /// Gets or sets number of milliseconds to delay delivery of re-queued messages.
+        /// </summary>
+        public int RequeueDelayInMilliseconds { get; private set; }
         /// <summary>
         /// Gets the unacceptable messages limit
         /// </summary>
@@ -87,8 +95,9 @@ namespace paramore.brighter.serviceactivator
         /// <param name="noOfPerformers">The no of performers.</param>
         /// <param name="timeoutInMilliseconds">The timeout in milliseconds.</param>
         /// <param name="requeueCount">The number of times you want to requeue a message before dropping it</param>
+        /// <param name="requeueDelayInMilliseconds">The number of milliseconds to delay the delivery of a requeue message for</param>
         /// <param name="unacceptableMessageLimit">The number of unacceptable messages to handle, before stopping reading from the channel</param>
-        public Connection(ConnectionName name, IAmAnInputChannel channel, Type dataType, int noOfPerformers = 1, int timeoutInMilliseconds = 300, int requeueCount = -1, int unacceptableMessageLimit = 0)
+        public Connection(ConnectionName name, IAmAnInputChannel channel, Type dataType, int noOfPerformers = 1, int timeoutInMilliseconds = 300, int requeueCount = -1, int requeueDelayInMilliseconds = 0, int unacceptableMessageLimit = 0)
         {
             RequeueCount = requeueCount;
             Name = name;
@@ -97,6 +106,7 @@ namespace paramore.brighter.serviceactivator
             NoOfPeformers = noOfPerformers;
             TimeoutInMiliseconds = timeoutInMilliseconds;
             UnacceptableMessageLimit = unacceptableMessageLimit;
+            RequeueDelayInMilliseconds = requeueDelayInMilliseconds;
         }
     }
 }

--- a/Brighter/paramore.brighter.serviceactivator/ConsumerFactory.cs
+++ b/Brighter/paramore.brighter.serviceactivator/ConsumerFactory.cs
@@ -49,6 +49,7 @@ namespace paramore.brighter.serviceactivator
                 Channel = _connection.Channel,
                 TimeoutInMilliseconds = _connection.TimeoutInMiliseconds,
                 RequeueCount = _connection.RequeueCount,
+                RequeueDelayInMilliseconds = _connection.RequeueDelayInMilliseconds,
                 UnacceptableMessageLimit = _connection.UnacceptableMessageLimit,
                 Logger = _logger
             };

--- a/Brighter/paramore.brighter.serviceactivator/MessagePump.cs
+++ b/Brighter/paramore.brighter.serviceactivator/MessagePump.cs
@@ -72,6 +72,10 @@ namespace paramore.brighter.serviceactivator
         /// <value>The requeue count.</value>
         public int RequeueCount { get; set; }
         /// <summary>
+        /// Gets or sets number of milliseconds to delay delivery of re-queued messages.
+        /// </summary>
+        public int RequeueDelayInMilliseconds { get; set; }
+        /// <summary>
         /// Gets or Sets the unacceptable message limit, once the limit is reached the 
         /// </summary>
         public int UnacceptableMessageLimit { get; set; }
@@ -305,7 +309,7 @@ namespace paramore.brighter.serviceactivator
 
             if (Logger != null) Logger.DebugFormat("MessagePump: Re-queueing message {0} from {2} on thread # {1}", message.Id, Thread.CurrentThread.ManagedThreadId, Channel.Name);
 
-            Channel.Requeue(message);
+            Channel.Requeue(message, RequeueDelayInMilliseconds);
         }
 
         private TRequest TranslateMessage(Message message)

--- a/Brighter/paramore.brighter.serviceactivator/ServiceActivatorConfiguration/ConnectionElement.cs
+++ b/Brighter/paramore.brighter.serviceactivator/ServiceActivatorConfiguration/ConnectionElement.cs
@@ -78,6 +78,13 @@ namespace paramore.brighter.serviceactivator.ServiceActivatorConfiguration
             set { this["requeueCount"] = value; }
         }
 
+        [ConfigurationProperty("requeueDelayInMilliseconds", DefaultValue = "0", IsRequired = false)]
+        public int RequeueDelayInMilliseconds
+        {
+            get { return Convert.ToInt32(this["requeueDelayInMilliseconds"]); }
+            set { this["requeueDelayInMilliseconds"] = value; }
+        }
+
         [ConfigurationProperty("unacceptableMessageLimit", DefaultValue = "0", IsRequired = false)]
         public int UnacceptableMessageLimit
         {

--- a/Brighter/paramore.brighter.serviceactivator/ServiceActivatorConfiguration/ConnectionFactory.cs
+++ b/Brighter/paramore.brighter.serviceactivator/ServiceActivatorConfiguration/ConnectionFactory.cs
@@ -50,6 +50,7 @@ namespace paramore.brighter.serviceactivator.ServiceActivatorConfiguration
                    noOfPerformers: connectionElement.NoOfPerformers,
                    timeoutInMilliseconds: connectionElement.TimeoutInMiliseconds,
                    requeueCount: connectionElement.RequeueCount,
+                   requeueDelayInMilliseconds: connectionElement.RequeueDelayInMilliseconds,
                    unacceptableMessageLimit: connectionElement.UnacceptableMessageLimit
                    )
              ).ToList();

--- a/Brighter/paramore.brighter.serviceactivator/TestHelpers/FakeChannel.cs
+++ b/Brighter/paramore.brighter.serviceactivator/TestHelpers/FakeChannel.cs
@@ -76,7 +76,7 @@ namespace paramore.brighter.serviceactivator.TestHelpers
             _messageQueue.Enqueue(MessageFactory.CreateQuitMessage());
         }
 
-        public virtual void Requeue(Message message)
+        public virtual void Requeue(Message message, int delayMilliseconds = 0)
         {
             _messageQueue.Enqueue(message);
         }

--- a/Brighter/paramore.brighter.serviceactivator/app.config.install.xdt
+++ b/Brighter/paramore.brighter.serviceactivator/app.config.install.xdt
@@ -22,7 +22,7 @@
   
   <serviceActivatorConnections>
     <connections>
-      <!--<add connectionName="TestConnectionName" channelName="TestChannelName" routingKey="TestRoutingKey" dataType="TestDataType" timeOutInMilliseconds="200"/>-->
+      <!--<add connectionName="TestConnectionName" channelName="TestChannelName" routingKey="TestRoutingKey" dataType="TestDataType" timeOutInMilliseconds="200" requeueDelayInMilliseconds="5000" />-->
     </connections>
   </serviceActivatorConnections>
 </configuration>


### PR DESCRIPTION
[In progress]

Initial implementation (for consideration/discussion) on delayed re-queueing, using message provider support where available. This version takes a simplistic approach that per connection you might want to specify a delay (in milliseconds) to re-queue messages for, and if messaging provider support be available, off-load it to the provider.

Brighter core;
  * InputChannel.Requeue(Message, DelayMilliseconds)
  * IAmAMessageProducerSupportingDelay.Send(Message, DelayMillisconds)
  * IAmAMessageConsumerSupportingDelay.Requeue(Message, DelayMilliseconds)
  * MessagerHeader.DelayedMilliseconds (incoming: delayed milliseconds, -1 if not applicable)
  * ServiceActivator `connection` attribute config `requeueDelayInMilliseconds` added

Provider support: RMQ;
  * Requires RabbitMQ 3.5+
  * Requires plugin "rabbitmq_delayed_message_exchange"
  * Use MachineSpec tag `RabbitMQDelayed` to exclude associated tests
  * CommandProcessor `rmqMessageGateway/exchange` config `supportDelay` added (enable/disable)
  * Exchange type of `x-delayed-message` and arg `x-message-type` required
  * Outgoing header `x-delay` set positive milliseconds to delay
  * Incoming header `x-delay` set negative milliseconds *IF* the message was delayed

.. and maybe some other stuff that skips my mind, likely because I'm drinking beer.