### PR TITLE
Move RequeueException to paramore.brighter.commandprocessor

### DIFF
--- a/Brighter/paramore.brighter.commandprocessor.tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections.Generic;
 
 using paramore.brighter.commandprocessor;
+using paramore.brighter.commandprocessor.exceptions;
 using paramore.brighter.serviceactivator;
 
 using Raven.Database.Indexing;

--- a/Brighter/paramore.brighter.commandprocessor/exceptions/RequeueException.cs
+++ b/Brighter/paramore.brighter.commandprocessor/exceptions/RequeueException.cs
@@ -37,7 +37,7 @@ THE SOFTWARE. */
 
 using System;
 
-namespace paramore.brighter.serviceactivator
+namespace paramore.brighter.commandprocessor.exceptions
 {
     /// <summary>
     /// Class RequeueException.

--- a/Brighter/paramore.brighter.commandprocessor/paramore.brighter.commandprocessor.csproj
+++ b/Brighter/paramore.brighter.commandprocessor/paramore.brighter.commandprocessor.csproj
@@ -56,6 +56,7 @@
     <Compile Include="ConfigurationException.cs" />
     <Compile Include="ChannelFailureException.cs" />
     <Compile Include="extensions\ReflectionExtensions.cs" />
+    <Compile Include="exceptions\RequeueException.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="HandlerConfiguration.cs" />
     <Compile Include="IAmAChannel.cs" />

--- a/Brighter/paramore.brighter.serviceactivator/MessagePump.cs
+++ b/Brighter/paramore.brighter.serviceactivator/MessagePump.cs
@@ -40,6 +40,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using paramore.brighter.commandprocessor;
 using paramore.brighter.commandprocessor.Logging;
+using paramore.brighter.commandprocessor.exceptions;
 using ConfigurationException = paramore.brighter.commandprocessor.ConfigurationException;
 
 namespace paramore.brighter.serviceactivator

--- a/Brighter/paramore.brighter.serviceactivator/paramore.brighter.serviceactivator.csproj
+++ b/Brighter/paramore.brighter.serviceactivator/paramore.brighter.serviceactivator.csproj
@@ -65,7 +65,6 @@
     <Compile Include="Ports\Handlers\ConfigurationCommandHandler.cs" />
     <Compile Include="Ports\Mappers\ConfigurationCommandMessageMapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="RequeueException.cs" />
     <Compile Include="ServiceActivatorConfiguration\ConnectionElement.cs" />
     <Compile Include="ServiceActivatorConfiguration\ConnectionElements.cs" />
     <Compile Include="ServiceActivatorConfiguration\ConnectionFactory.cs" />

--- a/release_notes.md
+++ b/release_notes.md
@@ -14,6 +14,7 @@ This section lists features in master, available by [AppVeyor](https://ci.appvey
 2. Fix issue with RabbitMQ consumers running on a High Availability cluster not cancelling properly after cluster failover.
 3. Fixed bug with config section duplication https://github.com/iancooper/Paramore/issues/52
 4. Added functionality so after a specified number of unacceptable message (unable to read from queue or map message) a connection is shutdown, by default unacceptable message are acked and dropped. https://github.com/iancooper/Paramore/issues/51
+5. Move RequeueException to paramore.brighter.commandprocessor.exceptions (breaking change).
 
 ## Release 3 ##
 


### PR DESCRIPTION
As discussed in the gitter.im room it's a PITA to have to reference serviceactivator assembly simply to throw a `RequeueException`, and whilst Brighter uses exceptions for flow-control - although technically not the responsibility of the `commandprocessor` - this seems sensible until it warrants a separate assembly with library cross-cutting concepts/primitives.