### PR TITLE
This fixes #30 RabbitMQ pipeline errors.

### DIFF
--- a/Brighter/Examples/TaskMailer/App.config
+++ b/Brighter/Examples/TaskMailer/App.config
@@ -31,7 +31,7 @@
   </rmqMessagingGateway>
   <serviceActivatorConnections>
     <connections>
-      <add connectionName="mail" channelName="Task.Reminder" routingKey="Task.Reminder" dataType="Tasks.Ports.Commands.TaskReminderCommand" noOfPerformers="1" timeOutInMilliseconds="200" />
+      <add connectionName="mail" channelName="Task.Reminder" routingKey="Task.Reminder" dataType="Tasks.Ports.Commands.TaskReminderCommand" noOfPerformers="2" timeOutInMilliseconds="200" />
     </connections>
   </serviceActivatorConnections>
 </configuration>

--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/ConnectionPolicyFactory.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/ConnectionPolicyFactory.cs
@@ -50,6 +50,8 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
     /// </summary>
     public class ConnectionPolicyFactory
     {
+        private const string PipeliningExceptionMessage = "Pipelining of requests forbidden";
+
         private readonly ILog _logger;
 
         /// <summary>
@@ -67,6 +69,7 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
 
             RetryPolicy = Policy.Handle<BrokerUnreachableException>()
                 .Or<Exception>()
+                .Or<NotSupportedException>(ex => ex.Message.Equals(PipeliningExceptionMessage, StringComparison.CurrentCultureIgnoreCase))
                 .WaitAndRetry(
                     retries,
                     retryAttempt => TimeSpan.FromMilliseconds(retryWaitInMilliseconds * Math.Pow(2, retryAttempt)),
@@ -76,6 +79,16 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
                         {
                             logger.WarnException(
                                 "RMQMessagingGateway: BrokerUnreachableException error on connecting to queue {0} exchange {1} on connection {2}. Will retry {3} times",
+                                exception,
+                                context["queueName"],
+                                configuration.Exchange.Name,
+                                configuration.AMPQUri.GetSanitizedUri(),
+                                retries);
+                        }
+                        else if (exception is NotSupportedException && exception.Message.Equals(PipeliningExceptionMessage, StringComparison.CurrentCultureIgnoreCase))
+                        {
+                            logger.InfoException(
+                                "RMQMessagingGateway: NotSupportedException:Pipelining error on connecting to queue {0} exchange {1} on connection {2}. Will retry {3} times",
                                 exception,
                                 context["queueName"],
                                 configuration.Exchange.Name,

--- a/Brighter/paramore.brighter.commandprocessor.tests/MessagingGateway/TestDoubles/BrokerUnreachableRmqMessageConsumer.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/MessagingGateway/TestDoubles/BrokerUnreachableRmqMessageConsumer.cs
@@ -42,7 +42,7 @@ namespace paramore.commandprocessor.tests.MessagingGateway.TestDoubles
         /// <param name="logger">The logger.</param>
         public BrokerUnreachableRmqMessageConsumer(string queueName, string routingKey, ILog logger) : base(queueName, routingKey, logger) { }
 
-        protected override void ConnectToBroker()
+        protected override void ConnectToBroker(string queueName)
         {
             throw new BrokerUnreachableException(new Exception("Force Test Failure"));
         }


### PR DESCRIPTION
The only issue I could find with this was that RMQ doesn't support pipelining as per the AMQP specification so needs a little time to clear the previously executing operation. Used the `ConnectionPolicyFactory` settings as isn't dissimilar.

For review/comment :)