### PR TITLE
When requeing a message we should use the default (empty) exchange so…

### DIFF
--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/RmqMessagePublisher.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/RmqMessagePublisher.cs
@@ -143,8 +143,9 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
             if (!message.Header.Bag.Any(h => h.Key.Equals(HeaderNames.ORIGINAL_MESSAGE_ID, StringComparison.CurrentCultureIgnoreCase)))
                 headers.Add(HeaderNames.ORIGINAL_MESSAGE_ID, message.Id.ToString());
 
+            // To send it to the right queue use the default (empty) exchange
             _channel.BasicPublish(
-                _exchangeName,
+                String.Empty,
                 queueName,
                 false,
                 false,


### PR DESCRIPTION
… that it gets delivered to the right queue