### PR TITLE
Replace `Successor` write-only property with `SetSuccessor` method.

### DIFF
--- a/Brighter/paramore.brighter.commandprocessor/IHandleRequests.cs
+++ b/Brighter/paramore.brighter.commandprocessor/IHandleRequests.cs
@@ -113,7 +113,7 @@ namespace paramore.brighter.commandprocessor
         /// <summary>
         /// Sets the successor.
         /// </summary>
-        /// <value>The successor.</value>
-        IHandleRequests<TRequest> Successor { set; }
+        /// <param name="successor">The successor.</param>
+        void SetSuccessor(IHandleRequests<TRequest> successor);
     }
 }

--- a/Brighter/paramore.brighter.commandprocessor/PipelineBuilder.cs
+++ b/Brighter/paramore.brighter.commandprocessor/PipelineBuilder.cs
@@ -104,7 +104,7 @@ namespace paramore.brighter.commandprocessor
             attributes.Each((attribute) =>
             {
                 var decorator = new HandlerFactory<TRequest>(attribute, _handlerFactory, requestContext).CreateRequestHandler();
-                lastInPipeline.Successor = decorator;
+                lastInPipeline.SetSuccessor(decorator);
                 lastInPipeline = decorator;
             });
         }
@@ -114,7 +114,7 @@ namespace paramore.brighter.commandprocessor
             attributes.Each((attribute) =>
             {
                 var decorator = new HandlerFactory<TRequest>(attribute, _handlerFactory, requestContext).CreateRequestHandler();
-                decorator.Successor = lastInPipeline;
+                decorator.SetSuccessor(lastInPipeline);
                 lastInPipeline = decorator;
             });
             return lastInPipeline;

--- a/Brighter/paramore.brighter.commandprocessor/RequestHandler.cs
+++ b/Brighter/paramore.brighter.commandprocessor/RequestHandler.cs
@@ -94,10 +94,10 @@ namespace paramore.brighter.commandprocessor
         /// <summary>
         /// Sets the successor.
         /// </summary>
-        /// <value>The successor.</value>
-        public IHandleRequests<TRequest> Successor
+        /// <param name="successor">The successor.</param>
+        public void SetSuccessor(IHandleRequests<TRequest> successor)
         {
-            set { _successor = value; }
+            _successor = successor;
         }
 
         /// <summary>


### PR DESCRIPTION
We had problems with our IoC container - it recognised that `Successor`
was a settable property with a type of `IHandleRequests<T>` and helpfully
tried to inject that property. This resulted in a loop of successors.

We worked around it eventually, but here's a patch replacing that
public setter with a method, in the hope that IoC containers won't
try and do something dumb with it.