### PR TITLE
Removed null check for consumer on creation

### DIFF
--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/RmqMessageConsumer.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/RmqMessageConsumer.cs
@@ -268,8 +268,7 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
 
         protected virtual void CreateConsumer()
         {
-            if(_consumer == null)
-                _consumer = new QueueingBasicConsumer(Channel);
+            _consumer = new QueueingBasicConsumer(Channel);
 
             Channel.BasicConsume(_queueName, AutoAck, string.Empty, SetConsumerArguments(), _consumer);
 


### PR DESCRIPTION
If I restart RMQ server, logs and RMQ console suggest that the consumers are connected successfully but they throw EndOfStreamException when reading messages from queue.
The problem was, there was a null check on consumer creation logic which was preventing the it's queue connection to be refreshed after the restart of RMQ server. Removing that check fixes the issue.