### PR TITLE
Removed the logger from RequestHandler<T> base class

### DIFF
--- a/Brighter/paramore.brighter.commandprocessor.tests/CommandProcessors/TestDoubles/MyPreAndPostDecoratedEventHandler.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/CommandProcessors/TestDoubles/MyPreAndPostDecoratedEventHandler.cs
@@ -1,0 +1,42 @@
+using System;
+using paramore.brighter.commandprocessor;
+using paramore.brighter.commandprocessor.Logging;
+
+namespace paramore.commandprocessor.tests.CommandProcessors.TestDoubles
+{
+    internal class MyPreAndPostDecoratedEventHandler : RequestHandler<MyEvent>, IDisposable
+    {
+        private static MyEvent s_command;
+        public static bool DisposeWasCalled { get; set; }
+
+        public MyPreAndPostDecoratedEventHandler(ILog logger)
+            : base(logger)
+        {
+            s_command = null;
+            DisposeWasCalled = false;
+        }
+
+        [MyPreValidationHandler(step: 2, timing: HandlerTiming.Before)]
+        [MyPostLoggingHandler(step: 1, timing: HandlerTiming.After)]
+        public override MyEvent Handle(MyEvent command)
+        {
+            LogCommand(command);
+            return base.Handle(command);
+        }
+
+        public static bool Shouldreceive(MyEvent expectedCommand)
+        {
+            return (s_command != null) && (expectedCommand.Id == s_command.Id);
+        }
+
+        private void LogCommand(MyEvent request)
+        {
+            s_command = request;
+        }
+
+        public void Dispose()
+        {
+            DisposeWasCalled = true;
+        }
+    }
+}

--- a/Brighter/paramore.brighter.commandprocessor.tests/ExceptionPolicy/TestDoubles/MyFailsWithFallbackDivideByZeroEventHandler.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/ExceptionPolicy/TestDoubles/MyFailsWithFallbackDivideByZeroEventHandler.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using paramore.brighter.commandprocessor;
+using paramore.brighter.commandprocessor.Logging;
+using paramore.brighter.commandprocessor.policy.Attributes;
+using paramore.brighter.commandprocessor.policy.Handlers;
+using paramore.commandprocessor.tests.CommandProcessors.TestDoubles;
+
+namespace paramore.commandprocessor.tests.ExceptionPolicy.TestDoubles
+{
+    internal class MyFailsWithFallbackDivideByZeroEventHandler : RequestHandler<MyEvent>
+    {
+        public MyFailsWithFallbackDivideByZeroEventHandler (ILog logger) : base(logger)
+        { }
+
+        public static bool FallbackCalled { get; set; }
+        public static bool ReceivedCommand { get; set; }
+        public static bool SetException { get; set; }
+
+        static MyFailsWithFallbackDivideByZeroEventHandler()
+        {
+            ReceivedCommand = false;
+        }
+
+        [FallbackPolicy(backstop: true, circuitBreaker: false, step: 1)]
+        public override MyEvent Handle(MyEvent command)
+        {
+            ReceivedCommand = true;
+            throw new DivideByZeroException();
+        }
+
+        public override MyEvent Fallback(MyEvent command)
+        {
+            FallbackCalled = true;
+            if (Context.Bag.ContainsKey(FallbackPolicyHandler<MyCommand>.CAUSE_OF_FALLBACK_EXCEPTION))
+                SetException = true;
+            return base.Fallback(command);
+        }
+
+        public static bool ShouldFallback(MyEvent command)
+        {
+            return FallbackCalled;
+        }
+
+        public static bool ShouldReceive(MyEvent myCommand)
+        {
+            return ReceivedCommand;
+        }
+
+        public static bool ShouldSetException(MyEvent myCommand)
+        {
+            return SetException;
+        }
+    }
+}

--- a/Brighter/paramore.brighter.commandprocessor.tests/paramore.brighter.commandprocessor.tests.csproj
+++ b/Brighter/paramore.brighter.commandprocessor.tests/paramore.brighter.commandprocessor.tests.csproj
@@ -165,6 +165,7 @@
     <Compile Include="EventSourcing\CommandStoreTests.cs" />
     <Compile Include="EventSourcing\TestDoubles\MyStoredCommandHandler.cs" />
     <Compile Include="ExceptionPolicy\FallbackSupportTests.cs" />
+    <Compile Include="ExceptionPolicy\TestDoubles\MyFailsWithFallbackDivideByZeroEventHandler.cs" />
     <Compile Include="ExceptionPolicy\TestDoubles\MyFailsWithFallbackMultipleHandlers.cs" />
     <Compile Include="ExceptionPolicy\TestDoubles\MyFailsWithUnsupportedExceptionForFallback.cs" />
     <Compile Include="ExceptionPolicy\TestDoubles\MyDoesNotFailPolicyHandler.cs" />

--- a/Brighter/paramore.brighter.commandprocessor.tests/paramore.brighter.commandprocessor.tests.csproj
+++ b/Brighter/paramore.brighter.commandprocessor.tests/paramore.brighter.commandprocessor.tests.csproj
@@ -125,6 +125,7 @@
     <Compile Include="CommandProcessors\TestDoubles\FakeMessageProducer.cs" />
     <Compile Include="CommandProcessors\TestDoubles\FakeMessageStore.cs" />
     <Compile Include="CommandProcessors\TestDoubles\MyMonitoredHandler.cs" />
+    <Compile Include="CommandProcessors\TestDoubles\MyPreAndPostDecoratedEventHandler.cs" />
     <Compile Include="CommandProcessors\TestDoubles\MyThrowingEventHandler.cs" />
     <Compile Include="CommandProcessors\TestDoubles\MyObsoleteCommandHandler.cs" />
     <Compile Include="CommandProcessors\TestDoubles\MyCommandMessageMapper.cs" />

--- a/Brighter/paramore.brighter.commandprocessor/CommandProcessor.cs
+++ b/Brighter/paramore.brighter.commandprocessor/CommandProcessor.cs
@@ -192,7 +192,9 @@ namespace paramore.brighter.commandprocessor
                 if (handlerCount == 0)
                     throw new ArgumentException(string.Format("No command handler was found for the typeof command {0} - a command should have only one handler.", typeof(T)));
 
-                handlerChain.First().Handle(command);
+                var handler = handlerChain.First();
+                handler.ContinuingPipeline += e => _logger.DebugFormat("Passing request from {0} to {1}", e.ThisHandler, e.NextHandler);
+                handler.Handle(command);
             }
         }
 
@@ -220,11 +222,12 @@ namespace paramore.brighter.commandprocessor
                 _logger.InfoFormat("Found {0} pipelines for event: {0}", handlerCount, @event.Id);
 
                 var exceptions = new List<Exception>();
-                foreach (var handleRequests in handlerChain)
+                foreach (var handler in handlerChain)
                 {
                     try
                     {
-                        handleRequests.Handle(@event);
+                        handler.ContinuingPipeline += e => _logger.DebugFormat("Passing request from {0} to {1}", e.ThisHandler, e.NextHandler);
+                        handler.Handle(@event);
                     }
                     catch (Exception e)
                     {
@@ -340,7 +343,7 @@ namespace paramore.brighter.commandprocessor
             }
 
             _messageStore = null;
-            _messagingGateway = null; 
+            _messagingGateway = null;
 
             _disposed = true;
         } 

--- a/Brighter/paramore.brighter.commandprocessor/CommandProcessor.cs
+++ b/Brighter/paramore.brighter.commandprocessor/CommandProcessor.cs
@@ -195,6 +195,8 @@ namespace paramore.brighter.commandprocessor
                 var handler = handlerChain.First();
                 handler.ContinuingPipeline += e => 
                     _logger.DebugFormat("Passing request from {0} to {1}", e.ThisHandler, e.NextHandler);
+                handler.FallingBack += e =>
+                   _logger.DebugFormat("Falling back from {0} to {1}", e.ThisHandler, e.NextHandler);
                 handler.Handle(command);
             }
         }
@@ -229,6 +231,9 @@ namespace paramore.brighter.commandprocessor
                     {
                         handler.ContinuingPipeline += e => 
                             _logger.DebugFormat("Passing request from {0} to {1}", e.ThisHandler, e.NextHandler);
+                        handler.FallingBack += e =>
+                           _logger.DebugFormat("Falling back from {0} to {1}", e.ThisHandler, e.NextHandler);
+
                         handler.Handle(@event);
                     }
                     catch (Exception e)

--- a/Brighter/paramore.brighter.commandprocessor/CommandProcessor.cs
+++ b/Brighter/paramore.brighter.commandprocessor/CommandProcessor.cs
@@ -193,7 +193,8 @@ namespace paramore.brighter.commandprocessor
                     throw new ArgumentException(string.Format("No command handler was found for the typeof command {0} - a command should have only one handler.", typeof(T)));
 
                 var handler = handlerChain.First();
-                handler.ContinuingPipeline += e => _logger.DebugFormat("Passing request from {0} to {1}", e.ThisHandler, e.NextHandler);
+                handler.ContinuingPipeline += e => 
+                    _logger.DebugFormat("Passing request from {0} to {1}", e.ThisHandler, e.NextHandler);
                 handler.Handle(command);
             }
         }
@@ -226,7 +227,8 @@ namespace paramore.brighter.commandprocessor
                 {
                     try
                     {
-                        handler.ContinuingPipeline += e => _logger.DebugFormat("Passing request from {0} to {1}", e.ThisHandler, e.NextHandler);
+                        handler.ContinuingPipeline += e => 
+                            _logger.DebugFormat("Passing request from {0} to {1}", e.ThisHandler, e.NextHandler);
                         handler.Handle(@event);
                     }
                     catch (Exception e)

--- a/Brighter/paramore.brighter.commandprocessor/FallingBackEvent.cs
+++ b/Brighter/paramore.brighter.commandprocessor/FallingBackEvent.cs
@@ -1,0 +1,14 @@
+namespace paramore.brighter.commandprocessor
+{
+    public class FallingBackEvent
+    {
+        public HandlerName ThisHandler { get; private set; }
+        public HandlerName NextHandler { get; private set; }
+
+        public FallingBackEvent(HandlerName thisHandler, HandlerName nextHandler)
+        {
+            ThisHandler = thisHandler;
+            NextHandler = nextHandler;
+        }
+    }
+}

--- a/Brighter/paramore.brighter.commandprocessor/IHandleRequests.cs
+++ b/Brighter/paramore.brighter.commandprocessor/IHandleRequests.cs
@@ -119,5 +119,6 @@ namespace paramore.brighter.commandprocessor
         void SetSuccessor(IHandleRequests<TRequest> successor);
 
         event Action<PipelineContinuingEvent> ContinuingPipeline;
+        event Action<FallingBackEvent> FallingBack;
     }
 }

--- a/Brighter/paramore.brighter.commandprocessor/IHandleRequests.cs
+++ b/Brighter/paramore.brighter.commandprocessor/IHandleRequests.cs
@@ -35,6 +35,8 @@ THE SOFTWARE. */
 
 #endregion
 
+using System;
+
 namespace paramore.brighter.commandprocessor
 {
     /// <summary>
@@ -115,5 +117,7 @@ namespace paramore.brighter.commandprocessor
         /// </summary>
         /// <param name="successor">The successor.</param>
         void SetSuccessor(IHandleRequests<TRequest> successor);
+
+        event Action<PipelineContinuingEvent> ContinuingPipeline;
     }
 }

--- a/Brighter/paramore.brighter.commandprocessor/PipelineContinuingEvent.cs
+++ b/Brighter/paramore.brighter.commandprocessor/PipelineContinuingEvent.cs
@@ -1,0 +1,14 @@
+namespace paramore.brighter.commandprocessor
+{
+    public class PipelineContinuingEvent
+    {
+        public HandlerName ThisHandler { get; private set; }
+        public HandlerName NextHandler { get; private set; }
+
+        public PipelineContinuingEvent(HandlerName thisHandler, HandlerName nextHandler)
+        {
+            ThisHandler = thisHandler;
+            NextHandler = nextHandler;
+        }
+    }
+}

--- a/Brighter/paramore.brighter.commandprocessor/RequestHandler.cs
+++ b/Brighter/paramore.brighter.commandprocessor/RequestHandler.cs
@@ -64,6 +64,7 @@ namespace paramore.brighter.commandprocessor
         /// <summary>
         /// The logger
         /// </summary>
+        [Obsolete("Use your own logger")]
         protected readonly ILog logger;
         private IHandleRequests<TRequest> _successor;
 
@@ -71,10 +72,13 @@ namespace paramore.brighter.commandprocessor
         /// Initializes a new instance of the <see cref="RequestHandler{TRequest}"/> class.
         /// </summary>
         /// <param name="logger">The logger.</param>
+        [Obsolete("Use the parameterless constructor")]
         protected RequestHandler(ILog logger)
         {
             this.logger = logger;
         }
+        protected RequestHandler()
+        {}
 
         /// <summary>
         /// Gets or sets the context.
@@ -98,6 +102,7 @@ namespace paramore.brighter.commandprocessor
         public void SetSuccessor(IHandleRequests<TRequest> successor)
         {
             _successor = successor;
+            _successor.ContinuingPipeline += (e) => ContinuingPipeline(e);
         }
 
         /// <summary>
@@ -123,6 +128,8 @@ namespace paramore.brighter.commandprocessor
                 _successor.DescribePath(pathExplorer);
         }
 
+        public event Action<PipelineContinuingEvent> ContinuingPipeline;
+
         /// <summary>
         /// Handles the specified command.
         /// </summary>
@@ -132,7 +139,7 @@ namespace paramore.brighter.commandprocessor
         {
             if (_successor != null)
             {
-                logger.DebugFormat("Passing request from {0} to {1}", Name, _successor.Name);
+                ContinuingPipeline(new PipelineContinuingEvent(Name, _successor.Name));
                 return _successor.Handle(command);
             }
 

--- a/Brighter/paramore.brighter.commandprocessor/RequestHandler.cs
+++ b/Brighter/paramore.brighter.commandprocessor/RequestHandler.cs
@@ -72,7 +72,7 @@ namespace paramore.brighter.commandprocessor
         /// Initializes a new instance of the <see cref="RequestHandler{TRequest}"/> class.
         /// </summary>
         /// <param name="logger">The logger.</param>
-        [Obsolete("Use the parameterless constructor")]
+        [Obsolete("Use the parameterless constructor and your own logger")]
         protected RequestHandler(ILog logger)
         {
             this.logger = logger;
@@ -102,7 +102,11 @@ namespace paramore.brighter.commandprocessor
         public void SetSuccessor(IHandleRequests<TRequest> successor)
         {
             _successor = successor;
-            _successor.ContinuingPipeline += (e) => ContinuingPipeline(e);
+            // Don't replace this with a reference to the ContinuingPipeline method group.
+            // If someone adds another subscription to ContinuingPipeline,
+            // this subscription won't get updated.
+            // We have to get ContinuingPipeline from the closure to get around this
+            _successor.ContinuingPipeline += (e) => this.ContinuingPipeline(e);
         }
 
         /// <summary>
@@ -128,7 +132,7 @@ namespace paramore.brighter.commandprocessor
                 _successor.DescribePath(pathExplorer);
         }
 
-        public event Action<PipelineContinuingEvent> ContinuingPipeline;
+        public event Action<PipelineContinuingEvent> ContinuingPipeline = e => {};
 
         /// <summary>
         /// Handles the specified command.
@@ -191,6 +195,5 @@ namespace paramore.brighter.commandprocessor
                 .Where(method => method.GetParameters().Count() == 1 && method.GetParameters().Single().ParameterType == typeof(TRequest))
                 .SingleOrDefault();
         }
-
     }
 }

--- a/Brighter/paramore.brighter.commandprocessor/RequestHandler.cs
+++ b/Brighter/paramore.brighter.commandprocessor/RequestHandler.cs
@@ -107,6 +107,7 @@ namespace paramore.brighter.commandprocessor
             // this subscription won't get updated.
             // We have to get ContinuingPipeline from the closure to get around this
             _successor.ContinuingPipeline += (e) => this.ContinuingPipeline(e);
+            _successor.FallingBack += (e) => this.FallingBack(e);
         }
 
         /// <summary>
@@ -132,7 +133,8 @@ namespace paramore.brighter.commandprocessor
                 _successor.DescribePath(pathExplorer);
         }
 
-        public event Action<PipelineContinuingEvent> ContinuingPipeline = e => {};
+        public event Action<PipelineContinuingEvent> ContinuingPipeline = e => { };
+        public event Action<FallingBackEvent> FallingBack = e => { };
 
         /// <summary>
         /// Handles the specified command.
@@ -173,7 +175,7 @@ namespace paramore.brighter.commandprocessor
         {
             if (_successor != null)
             {
-                logger.DebugFormat("Falling back from {0} to {1}", Name, _successor.Name);
+                FallingBack(new FallingBackEvent(Name, _successor.Name));
                 return _successor.Fallback(command);
             }
             return command;

--- a/Brighter/paramore.brighter.commandprocessor/paramore.brighter.commandprocessor.csproj
+++ b/Brighter/paramore.brighter.commandprocessor/paramore.brighter.commandprocessor.csproj
@@ -82,6 +82,7 @@
     <Compile Include="monitoring\Attributes\MonitorAttribute.cs" />
     <Compile Include="monitoring\Events\MonitorEvent.cs" />
     <Compile Include="monitoring\Handlers\MonitorHandler.cs" />
+    <Compile Include="PipelineContinuingEvent.cs" />
     <Compile Include="PolicyRegistry.cs" />
     <Compile Include="policy\Attributes\FallbackPolicyAttribute.cs" />
     <Compile Include="policy\Attributes\TimeoutPolicyAttribute.cs" />

--- a/Brighter/paramore.brighter.commandprocessor/paramore.brighter.commandprocessor.csproj
+++ b/Brighter/paramore.brighter.commandprocessor/paramore.brighter.commandprocessor.csproj
@@ -59,6 +59,7 @@
     <Compile Include="eventsourcing\Handlers\CommandSourcingHandler.cs" />
     <Compile Include="extensions\ReflectionExtensions.cs" />
     <Compile Include="actions\DeferMessageAction.cs" />
+    <Compile Include="FallingBackEvent.cs" />
     <Compile Include="HandlerConfiguration.cs" />
     <Compile Include="IAmAChannel.cs" />
     <Compile Include="IAmAChannelFactory.cs" />


### PR DESCRIPTION
`RequestHandler` took a logger into its constructor, so that when it continues the pipeline by calling `_successor.Handle` it's able to log the names of the current handler and the next handler.

We found this painful, because when we converted to Brighter every single one of our handlers had to take an `ILog` dependency - and it was _Brighter's_ `ILog`, not the logging interface of our choice. (Even if we were using LibLog, we still wouldn't be able to use the copy of `LibLog` that we'd imported.) So the options were:
  * Have _two_ loggers (of different interfaces) injected into every
    handler - one so that Brighter can log pipeline continuations and
    another so that we can do our application-level logging.
  * Abandon our old logging interface and use the _Brighter_ `ILog`
    everywhere.

Neither option is particularly palatable. In my opinion, the logger should be injected into Brighter _once_ at the entry point to the whole system (when we build the command processor), not at every handler.

So with that in mind, I've excised the `ILog` from `RequestHandler` altogether. I replaced it with a more generalised solution - an `event` (a C# `event`, not a Brighter `Event`) on `IHandleRequests` to indicate that the pipeline is continuing. `RequestHandler` invokes that event when it calls `_successor.Handle`, and propagates calls from its successor up the pipeline. In `CommandProcessor` itself, the event is bound to the actual logger.

I kept the old constructor (and field) in, because there'll be code which depends on it, but I deprecated them.

I'm going to throw up another pull request to remove usages of the deprecated constructor in a little while