### PR TITLE
Add message body to log output when a message is dropped.

### DIFF
--- a/Brighter/paramore.brighter.commandprocessor.tests/MessageDispatch/MessagePumpFixture.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/MessageDispatch/MessagePumpFixture.cs
@@ -28,7 +28,6 @@ using System.Threading.Tasks;
 using Machine.Specifications;
 using Newtonsoft.Json;
 using paramore.brighter.commandprocessor;
-using paramore.brighter.commandprocessor.Logging;
 using paramore.brighter.serviceactivator;
 using paramore.brighter.serviceactivator.TestHelpers;
 using paramore.commandprocessor.tests.CommandProcessors.TestDoubles;

--- a/Brighter/paramore.brighter.commandprocessor.tests/MessageDispatch/MessagePumpFixture.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/MessageDispatch/MessagePumpFixture.cs
@@ -28,6 +28,7 @@ using System.Threading.Tasks;
 using Machine.Specifications;
 using Newtonsoft.Json;
 using paramore.brighter.commandprocessor;
+using paramore.brighter.commandprocessor.Logging;
 using paramore.brighter.serviceactivator;
 using paramore.brighter.serviceactivator.TestHelpers;
 using paramore.commandprocessor.tests.CommandProcessors.TestDoubles;

--- a/Brighter/paramore.brighter.serviceactivator/MessagePump.cs
+++ b/Brighter/paramore.brighter.serviceactivator/MessagePump.cs
@@ -303,12 +303,13 @@ namespace paramore.brighter.serviceactivator
 
                     if (Logger != null) 
                         Logger.ErrorFormat(
-                            "MessagePump: Have tried {2} times to handle this message {0}{4} from {3} on thread # {1}, dropping message", 
+                            "MessagePump: Have tried {2} times to handle this message {0}{4} from {3} on thread # {1}, dropping message. Message Body: {5}", 
                             message.Id, 
                             Thread.CurrentThread.ManagedThreadId, 
                             RequeueCount, 
                             Channel.Name,
-                            string.IsNullOrEmpty(originalMessageId) ? string.Empty : string.Format(" (original message id {0})", originalMessageId));
+                            string.IsNullOrEmpty(originalMessageId) ? string.Empty : string.Format(" (original message id {0})", originalMessageId),
+                            message.Body.Value);
 
                     AcknowledgeMessage(message);
                     return;

--- a/Brighter/paramore.brighter.serviceactivator/MessagePump.cs
+++ b/Brighter/paramore.brighter.serviceactivator/MessagePump.cs
@@ -303,12 +303,13 @@ namespace paramore.brighter.serviceactivator
 
                     if (Logger != null) 
                         Logger.ErrorFormat(
-                            "MessagePump: Have tried {2} times to handle this message {0}{4} from {3} on thread # {1}, dropping message. Message Body: {5}", 
+                            "MessagePump: Have tried {2} times to handle this message {0}{4} from {3} on thread # {1}, dropping message.{5}Message Body:{6}", 
                             message.Id, 
                             Thread.CurrentThread.ManagedThreadId, 
                             RequeueCount, 
                             Channel.Name,
                             string.IsNullOrEmpty(originalMessageId) ? string.Empty : string.Format(" (original message id {0})", originalMessageId),
+                            Environment.NewLine,
                             message.Body.Value);
 
                     AcknowledgeMessage(message);


### PR DESCRIPTION
Hi,

When a message is dropped, we get a useful error message alerting us that it has happened.  However, it only logs the message id, and that makes taking remedial action a bit more difficult, because we have to locate the original message to understand what has changed.

It would be great if the message could also include the message body.