### PR TITLE
Fix #132 by serialising access to the Producer.

### DIFF
--- a/Brighter/paramore.brighter.comandprocessor.messageviewer/Ports/Handlers/RepostCommandHandler.cs
+++ b/Brighter/paramore.brighter.comandprocessor.messageviewer/Ports/Handlers/RepostCommandHandler.cs
@@ -35,7 +35,7 @@ namespace paramore.brighter.commandprocessor.messageviewer.Ports.Handlers
 
             foreach (var foundMessage in foundMessages)
             {
-                foundProducer.Send(foundMessage).Wait();
+                foundProducer.Send(foundMessage);
             }
         }
 

--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.awssqs/SqsMessageProducer.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.awssqs/SqsMessageProducer.cs
@@ -21,7 +21,7 @@ namespace paramore.brighter.commandprocessor.messaginggateway.awssqs
             _logger = logger;
         }
 
-        public Task Send(Message message)
+        public void Send(Message message)
         {
             var messageString = JsonConvert.SerializeObject(message);
             _logger.DebugFormat("SQSMessageProducer: Publishing message with topic {0} and id {1} and message: {2}", message.Header.Topic, message.Id, messageString);
@@ -31,7 +31,7 @@ namespace paramore.brighter.commandprocessor.messaginggateway.awssqs
                 var topicArn = EnsureTopic(message.Header.Topic, client);
 
                 var publishRequest = new PublishRequest(topicArn, messageString);
-                return client.PublishAsync(publishRequest);
+                client.PublishAsync(publishRequest).Wait();
             }
         }
 

--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.restms/RestMsMessageProducer.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.restms/RestMsMessageProducer.cs
@@ -71,11 +71,8 @@ namespace paramore.brighter.commandprocessor.messaginggateway.restms
         /// Sends the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        /// <returns>Task.</returns>
-        public Task Send(Message message)
+        public void Send(Message message)
         {
-            var tcs = new TaskCompletionSource<object>();
-
             try
             {
                 _feed.EnsureFeedExists(_domain.GetDomain());
@@ -84,18 +81,13 @@ namespace paramore.brighter.commandprocessor.messaginggateway.restms
             catch (RestMSClientException rmse)
             {
                 Logger.ErrorFormat("Error sending to the RestMS server: {0}", rmse.ToString());
-                tcs.SetException(rmse);
                 throw;
             }
             catch (HttpRequestException he)
             {
                 Logger.ErrorFormat("HTTP error on request to the RestMS server: {0}", he.ToString());
-                tcs.SetException(he);
                 throw;
             }
-
-            tcs.SetResult(new object());
-            return tcs.Task;
         }
 
 

--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/MessageGateway.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/MessageGateway.cs
@@ -124,7 +124,7 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
         {
             if (Channel == null || Channel.IsClosed)
             {
-                var connection = new  MessageGatewayConnectionPool().GetConnection(_connectionFactory);
+                var connection = new MessageGatewayConnectionPool().GetConnection(_connectionFactory);
 
                 Logger.DebugFormat("RMQMessagingGateway: Opening channel to Rabbit MQ on connection {0}", Configuration.AMPQUri.GetSanitizedUri());
 
@@ -133,7 +133,9 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
                 //When AutoClose is true, the last channel to close will also cause the connection to close1. If it is set to
                 //true before any channel is created, the connection will close then and there.
                 if (connection.AutoClose == false)
+                {
                     connection.AutoClose = true;
+                }
 
                 // Configure the Quality of service for the model.
                 // BasicQos(0="Don't send me a new message until I?ve finished",  1= "Send me one message at a time", false ="Applied separately to each new consumer on the channel")

--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/RmqMessageConsumer.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/RmqMessageConsumer.cs
@@ -50,7 +50,7 @@ using RabbitMQ.Client.Exceptions;
 namespace paramore.brighter.commandprocessor.messaginggateway.rmq
 {
     /// <summary>
-    /// Class ServerRequestHandler .
+    /// Class RmqMessageConsumer.
     /// The <see cref="RmqMessageConsumer"/> is used on the server to receive messages from the broker. It abstracts away the details of 
     /// inter-process communication tasks from the server. It handles connection establishment, request reception and dispatching, 
     /// result sending, and error handling.

--- a/Brighter/paramore.brighter.commandprocessor.tests/CommandProcessors/TestDoubles/FakeMessageProducer.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/CommandProcessors/TestDoubles/FakeMessageProducer.cs
@@ -42,13 +42,9 @@ namespace paramore.commandprocessor.tests.CommandProcessors.TestDoubles
         /// </summary>
         /// <param name="message">The message.</param>
         /// <returns>Task.</returns>
-        public Task Send(Message message)
+        public void Send(Message message)
         {
-            var tcs = new TaskCompletionSource<object>();
             MessageWasSent = true;
-
-            tcs.SetResult(new object());
-            return tcs.Task;
         }
     }
 
@@ -65,7 +61,7 @@ namespace paramore.commandprocessor.tests.CommandProcessors.TestDoubles
         /// </summary>
         /// <param name="message">The message.</param>
         /// <returns>Task.</returns>
-        public Task Send(Message message)
+        public void Send(Message message)
         {
             SentCalledCount++;
             throw new Exception();

--- a/Brighter/paramore.brighter.commandprocessor/CommandProcessor.cs
+++ b/Brighter/paramore.brighter.commandprocessor/CommandProcessor.cs
@@ -267,7 +267,7 @@ namespace paramore.brighter.commandprocessor
             RetryAndBreakCircuit(() =>
                 {
                     _messageStore.Add(message).Wait(_messageStoreWriteTimeout);
-                    _messagingGateway.Send(message).Wait(_messageGatewaySendTimeout);
+                    _messagingGateway.Send(message);
                 });
         }
 
@@ -300,7 +300,7 @@ namespace paramore.brighter.commandprocessor
                         return;
                     }
 
-                    _messagingGateway.Send(message).Wait();
+                    _messagingGateway.Send(message);
                 });
         }
 

--- a/Brighter/paramore.brighter.commandprocessor/IAmAMessageProducer.cs
+++ b/Brighter/paramore.brighter.commandprocessor/IAmAMessageProducer.cs
@@ -57,8 +57,7 @@ namespace paramore.brighter.commandprocessor
         /// Sends the specified message.
         /// </summary>
         /// <param name="message">The message.</param>
-        /// <returns>Task.</returns>
-        Task Send(Message message);
+        void Send(Message message);
     }
 
     /// <summary>
@@ -78,7 +77,6 @@ namespace paramore.brighter.commandprocessor
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="delayMilliseconds">Number of milliseconds to delay delivery of the message.</param>
-        /// <returns>Task.</returns>
-        Task Send(Message message, int delayMilliseconds);
+        void Send(Message message, int delayMilliseconds);
     }
 }

--- a/Brighter/paramore.brighter.commandprocessor/OutputChannel.cs
+++ b/Brighter/paramore.brighter.commandprocessor/OutputChannel.cs
@@ -73,9 +73,9 @@ namespace paramore.brighter.commandprocessor
                 Task.Delay(delayMilliseconds).Wait();
 
             if (_messageProducerSupportsDelay)
-                (_messageProducer as IAmAMessageProducerSupportingDelay).Send(message, delayMilliseconds).Wait();
+                (_messageProducer as IAmAMessageProducerSupportingDelay).Send(message, delayMilliseconds);
             else
-                _messageProducer.Send(message).Wait();
+                _messageProducer.Send(message);
         }
 
         /// <summary>

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,11 +1,16 @@
 # Release Notes #
 NuGet packages for the last good build on master are available via [AppVeyor](https://ci.appveyor.com/project/IanCooper/paramore) (see Artifacts). The simplest way to work with this is to create a local NuGet source in Visual Studio for a shared directory visible to your team and download the packages there.
- 
+
 When we push a collection of functionality it is available via [nuget.org](http://www.nuget.org) and symbol files are published to [symbolsource.org](http://www.symbolsource.org)
- 
+
 This section lists features in master, available by [AppVeyor](https://ci.appveyor.com/project/IanCooper/paramore), but not yet deployed to [nuget.org](http://www.nuget.org).
 
 ## Master ##
+
+**Bug fixes**:
+ - Fixed issue #132: concurrent usages of the RabbitMQ messaging gateway would sometimes throw an exception
+
+
 ## Release 5 ##
 
 **Bug Fixes:**
@@ -44,7 +49,7 @@ This section lists features in master, available by [AppVeyor](https://ci.appvey
 5. Delayed message provider support for RabbitMQ using [rabbitmq_delayed_message_exchange plugin (3.5+)](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/).
 6. Renamed RequeueException to DeferMessageAction and moved it into the command processor project.
 7. Fixed and issues with unhandled exceptions from handlers when an event is published not been logged correctly
-8. The first early version of a Message Store Viewer has been release as a zip file download 
+8. The first early version of a Message Store Viewer has been release as a zip file download
 
 ## Release 3.0.129 ##
 1. We now support a Fallback method on IHandleRequests<TRequest> which is intended to be used for compensating or emergency action when a Handle method cannot be executed. The [FallbackPolicy] attribute supports the pipeline calling the Fallback method for you, in the event of either any exception bubbling into the handler, or a broken circuit exception bubbling into the handler.
@@ -57,7 +62,7 @@ This section lists features in master, available by [AppVeyor](https://ci.appvey
 
 
 1. Refactored **IAmAMessagingGateway** into a **IAmAMessageConsumer** and **IAmAMessageProducer** to support differing approaches to producing and consuming messages for a particular flavour of Message-Oriented-Middleware. *These changes are a breaking binary change for users of earlier versions.*
-	1. NOTE: IF YOU USE TASK QUEUES PLEASE SAVE YOUR SERVICEACTIVATORCONNECTIONS IN YOUR APP.CONFIG AS THE V2.0.1 BRIGHTER.SERVICEACTIVATOR UNINSTALL WILL DELETE THEM (FIXED FOR V3)	
+	1. NOTE: IF YOU USE TASK QUEUES PLEASE SAVE YOUR SERVICEACTIVATORCONNECTIONS IN YOUR APP.CONFIG AS THE V2.0.1 BRIGHTER.SERVICEACTIVATOR UNINSTALL WILL DELETE THEM (FIXED FOR V3)
 2. Created an **IAmAChannel** abstraction to allow differing Application Layer dependencies for the Work Queue
 2. Upgraded Packages we depend on, including RabbitMQ. *There is still an issue with our having a hard dependency on a RabbitMQ client that might vary from your RabbitMQ client version, but as a NuGet package there are few workarounds. We suggest building from source where this issue is problematic, for now.*
 3. Significant stability improvements on the RabbitMQ client
@@ -66,5 +71,5 @@ This section lists features in master, available by [AppVeyor](https://ci.appvey
 	3. Provided support for a **RequeueException** to requeue messages that are 'out-of-time' to help with resequencing.
 	1. We now dispose of channels aggressively on closure, instead of waiting for garbage collection
 2. Moved from [Common.Logging](https://github.com/net-commons/common-logging) to [LibLog](https://github.com/damianh/LibLog)  *These changes are a breaking binary change for users of earlier versions.*
-3. We now call Release for all **RequestHandler<>** derived handlers that we construct from an **IAmAHandlerFactory**, not just those that implement IDisposable. 
+3. We now call Release for all **RequestHandler<>** derived handlers that we construct from an **IAmAHandlerFactory**, not just those that implement IDisposable.
 4. Note that the RestMS server is **NOT** ready for production usage. It's primary value, as of today, is an alternative to RabbitMQ for design purposes. It is hoped to produce a stable version for use as a ControlBus in a future release.


### PR DESCRIPTION
I made the return type of `MessagingGateway.Send` into `void` (instead of `Task`). The `Task` was always immediately being awaited.

This is going to break backwards compatibility with anyone that was using or implementing `IAmAMessageProducer`, but @iancooper doesn't think there is anyone doing that, so it's a risk we are willing to take.

The "proper" way to do it is to restrict access to the RabbitMQ connection to a single thread (an actor). `Send` would ask the actor to publish the message and return a `Task` which will be completed when the actor has successfully published it. We decided it wasn't worth the effort of going down this route yet, since there's no `PostAsync` on the `CommandProcessor` in the first place; instead we are simply using a critical section. That's something you'll have to deal with in the future.