### PR TITLE
Restore `EnsureChannel` call

### DIFF
--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/RmqMessageProducer.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/RmqMessageProducer.cs
@@ -14,10 +14,10 @@
 
 #region Licence
 /* The MIT License (MIT)
-Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+Copyright ¬© 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the ìSoftwareî), to deal
+of this software and associated documentation files (the ‚ÄúSoftware‚Äù), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
@@ -26,7 +26,7 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED ìAS ISî, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED ‚ÄúAS IS‚Äù, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
@@ -76,9 +76,9 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
         /// <returns>Task.</returns>
         public void SendWithDelay(Message message, int delayMilliseconds = 0)
         {
-
             Logger.DebugFormat("RmqMessageProducer: Preparing  to sending message via exchange {0}", Configuration.Exchange.Name);
 
+            EnsureChannel();
             var rmqMessagePublisher = new RmqMessagePublisher(Channel, Configuration.Exchange.Name, Logger);
             Logger.DebugFormat("RmqMessageProducer: Publishing message to exchange {0} on connection {1} with a delay of {5} and topic {2} and id {3} and body: {4}", Configuration.Exchange.Name, Configuration.AMPQUri.GetSanitizedUri(), message.Header.Topic, message.Id, message.Body.Value, delayMilliseconds);
             rmqMessagePublisher.PublishMessage(message, delayMilliseconds);


### PR DESCRIPTION
I'm assuming this got accidentally deleted in the merge: https://github.com/iancooper/Paramore/commit/f23ca10e7abeeb1378ce658578eac81014e3dbe8#diff-341cadd67b9b9cda1d215d6326ecdb9dL82