### PR TITLE
Fixes Issue #76 - Should Send be constrained to take a Command and

### DIFF
--- a/Brighter/paramore.brighter.commandprocessor.tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
@@ -45,7 +45,7 @@ namespace paramore.commandprocessor.tests.MessageDispatch.TestDoubles
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="command">The command.</param>
-        public virtual void Send<T>(T command) where T : class, IRequest
+        public virtual void Send<T>(T command) where T : class, ICommand
         {
             _requests.Enqueue(command);
             SendHappened = true;
@@ -56,7 +56,7 @@ namespace paramore.commandprocessor.tests.MessageDispatch.TestDoubles
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="event">The event.</param>
-        public virtual void Publish<T>(T @event) where T : class, IRequest
+        public virtual void Publish<T>(T @event) where T : class, IEvent
         {
             _requests.Enqueue(@event);
             PublishHappened = true;
@@ -71,16 +71,6 @@ namespace paramore.commandprocessor.tests.MessageDispatch.TestDoubles
         {
             _requests.Enqueue(request);
             PostHappened = true;
-        }
-
-        /// <summary>
-        /// Reposts the specified message identifier.
-        /// </summary>
-        /// <param name="messageId">The message identifier.</param>
-        public virtual void Repost(Guid messageId)
-        {
-            RepostHappened = true;
-            return;
         }
 
         public virtual T Observe<T>() where T : class, IRequest

--- a/Brighter/paramore.brighter.commandprocessor/CommandProcessor.cs
+++ b/Brighter/paramore.brighter.commandprocessor/CommandProcessor.cs
@@ -174,7 +174,7 @@ namespace paramore.brighter.commandprocessor
         /// <param name="command">The command.</param>
         /// <exception cref="System.ArgumentException">
         /// </exception>
-        public void Send<T>(T command) where T : class, IRequest
+        public void Send<T>(T command) where T : class, ICommand
         {
             using (var builder = new PipelineBuilder<T>(_subscriberRegistry, _handlerFactory, _logger))
             {
@@ -205,7 +205,7 @@ namespace paramore.brighter.commandprocessor
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="event">The event.</param>
-        public void Publish<T>(T @event) where T : class, IRequest
+        public void Publish<T>(T @event) where T : class, IEvent
         {
             using (var builder = new PipelineBuilder<T>(_subscriberRegistry, _handlerFactory, _logger))
             {

--- a/Brighter/paramore.brighter.commandprocessor/Event.cs
+++ b/Brighter/paramore.brighter.commandprocessor/Event.cs
@@ -44,7 +44,7 @@ namespace paramore.brighter.commandprocessor
     /// An event is an indicator to interested parties that 'something has happened'. We expect zero to many receivers as it is one-to-many communication i.e. publish-subscribe
     /// An event is usually fire-and-forget, because we do not know it is received.
     /// </summary>
-    public class Event : IRequest
+    public class Event : IEvent
     {
         /// <summary>
         /// Gets or sets the identifier.

--- a/Brighter/paramore.brighter.commandprocessor/IEvent.cs
+++ b/Brighter/paramore.brighter.commandprocessor/IEvent.cs
@@ -35,37 +35,14 @@ THE SOFTWARE. */
 
 #endregion
 
-using System;
-
 namespace paramore.brighter.commandprocessor
 {
     /// <summary>
-    /// Interface IAmACommandProcessor
-    /// Paramore.Brighter.CommandProcessor provides the default implementation of this interface <see cref="CommandProcessor"/> and it is unlikely you need
-    /// to override this for anything other than testing purposes. The usual need is that in a <see cref="RequestHandler{T}"/> you intend to publish an  
-    /// <see cref="Event"/> to indicate the handler has completed to other components. In this case your tests should only verify that the correct 
-    /// event was raised by listening to <see cref="Publish{T}"/> calls on this interface, using a mocking framework of your choice or bespoke
-    /// Test Double.
+    /// Class Event
+    /// An event is an indicator to interested parties that 'something has happened'. We expect zero to many receivers as it is one-to-many communication i.e. publish-subscribe
+    /// An event is usually fire-and-forget, because we do not know it is received.
     /// </summary>
-    public interface IAmACommandProcessor
+    public interface IEvent : IRequest
     {
-        /// <summary>
-        /// Sends the specified command.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="command">The command.</param>
-        void Send<T>(T command) where T : class, ICommand;
-        /// <summary>
-        /// Publishes the specified event. Throws an aggregate exception on failure of a pipeline but executes remaining
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="event">The event.</param>
-        void Publish<T>(T @event) where T : class, IEvent;
-        /// <summary>
-        /// Posts the specified request.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="request">The request.</param>
-        void Post<T>(T request) where T : class, IRequest;
     }
 }

--- a/Brighter/paramore.brighter.commandprocessor/paramore.brighter.commandprocessor.csproj
+++ b/Brighter/paramore.brighter.commandprocessor/paramore.brighter.commandprocessor.csproj
@@ -80,6 +80,7 @@
     <Compile Include="IAmAPolicyRegistry.cs" />
     <Compile Include="IAmAMessageProducer.cs" />
     <Compile Include="IAmAMessageConsumer.cs" />
+    <Compile Include="IEvent.cs" />
     <Compile Include="InMemoryCommandStore.cs" />
     <Compile Include="MessageRecovery.cs" />
     <Compile Include="monitoring\Configuration\MonitoringConfigurationSection.cs" />


### PR DESCRIPTION
Publish an Event?
- Extracted new IEvent interface
- Constrained CommandProcessor etc
- MessagePump now IGNORES messageType and uses type for dispatch