### PR TITLE
Add async/await support for Send via the implementation of SendAsync

### DIFF
--- a/Brighter/Examples/HelloWorldAsync/App.config
+++ b/Brighter/Examples/HelloWorldAsync/App.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Brighter/Examples/HelloWorldAsync/GreetingCommand.cs
+++ b/Brighter/Examples/HelloWorldAsync/GreetingCommand.cs
@@ -1,0 +1,40 @@
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using paramore.brighter.commandprocessor;
+
+namespace HelloWorldAsync
+{
+    internal class GreetingCommand : Command
+    {
+        public GreetingCommand(string name)
+            : base(new Guid())
+        {
+            Name = name;
+        }
+
+        public string Name { get; private set; }
+    }
+}

--- a/Brighter/Examples/HelloWorldAsync/GreetingCommandAsyncHandler.cs
+++ b/Brighter/Examples/HelloWorldAsync/GreetingCommandAsyncHandler.cs
@@ -1,0 +1,45 @@
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using paramore.brighter.commandprocessor;
+
+namespace HelloWorldAsync
+{
+    internal class GreetingCommandAsyncHandler : AsyncRequestHandler<GreetingCommand>
+    {
+        public override async Task<GreetingCommand> HandleAsync(GreetingCommand command)
+        {
+            var api = new IpFyApi(new Uri("https://api.ipify.org"));
+
+            var result = await api.GetAsync();
+
+            Console.WriteLine("Hello {0}", command.Name);
+            Console.WriteLine(result.Success ? "Your public IP addres is {0}" : "Call to IpFy API failed : {0}",
+                result.Message);
+            return await base.HandleAsync(command);
+        }
+    }
+}

--- a/Brighter/Examples/HelloWorldAsync/HelloWorldAsync.csproj
+++ b/Brighter/Examples/HelloWorldAsync/HelloWorldAsync.csproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D7D027C1-8C8B-4334-A695-7B0D139B44CD}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>HelloWorldAsync</RootNamespace>
+    <AssemblyName>HelloWorldAsync</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="GreetingCommand.cs" />
+    <Compile Include="GreetingCommandAsyncHandler.cs" />
+    <Compile Include="IpFyApi.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\paramore.brighter.commandprocessor\paramore.brighter.commandprocessor.csproj">
+      <Project>{2acb382a-38fa-49a6-a9cd-212881d3cd37}</Project>
+      <Name>paramore.brighter.commandprocessor</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Brighter/Examples/HelloWorldAsync/IpFyApi.cs
+++ b/Brighter/Examples/HelloWorldAsync/IpFyApi.cs
@@ -1,0 +1,69 @@
+﻿#region Licence
+/* The MIT License (MIT)
+Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace HelloWorldAsync
+{
+    internal struct IpFyApiResult
+    {
+        public IpFyApiResult(bool success, string message) : this()
+        {
+            Success = success;
+            Message = message;
+        }
+
+        public bool Success { get; private set; }
+        public string Message { get; private set; }
+    }
+
+    internal class IpFyApi
+    {
+        private readonly Uri _endpoint;
+
+        public IpFyApi(Uri endpoint)
+        {
+            _endpoint = endpoint;
+        }
+
+        public async Task<IpFyApiResult> GetAsync()
+        {
+            using (var client = new HttpClient())
+            {
+                client.BaseAddress = _endpoint;
+                client.DefaultRequestHeaders.Clear();
+
+                var response = await client.GetAsync("");
+                string result;
+                if (response.IsSuccessStatusCode)
+                    result = await response.Content.ReadAsStringAsync();
+                else
+                    result = "API returned HTTP status " + response.StatusCode;
+                return new IpFyApiResult(response.IsSuccessStatusCode, result);
+            }
+        }
+    }
+}

--- a/Brighter/Examples/HelloWorldAsync/Program.cs
+++ b/Brighter/Examples/HelloWorldAsync/Program.cs
@@ -1,0 +1,73 @@
+﻿#region Licence
+
+/* The MIT License (MIT)
+Copyright © 2015 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using paramore.brighter.commandprocessor;
+
+namespace HelloWorldAsync
+{
+    internal class Program
+    {
+        private static void Main()
+        {
+            // Use bootstrapper for async/await in Console app
+            MainAsync().Wait();
+        }
+
+        private static async Task MainAsync()
+        {
+            var registry = new SubscriberRegistry();
+            registry.RegisterAsync<GreetingCommand, GreetingCommandAsyncHandler>();
+
+            var builder = CommandProcessorBuilder.With()
+                .Handlers(new HandlerConfiguration(registry, new SimpleAsyncHandlerFactory()))
+                .DefaultPolicy()
+                .NoTaskQueues()
+                .RequestContextFactory(new InMemoryRequestContextFactory());
+
+            var commandProcessor = builder.Build();
+
+            // To allow the command handler(s) to release the thread
+            // while doing potentially long running operations,
+            // await the async (but inline) handling of the command
+            await commandProcessor.SendAsync(new GreetingCommand("Ian"));
+
+            Console.ReadLine();
+        }
+
+        internal class SimpleAsyncHandlerFactory : IAmAnAsyncHandlerFactory
+        {
+            public void Release(IHandleRequestsAsync handler)
+            {
+            }
+
+            IHandleRequestsAsync IAmAnAsyncHandlerFactory.Create(Type handlerType)
+            {
+                return new GreetingCommandAsyncHandler();
+            }
+        }
+    }
+}

--- a/Brighter/Examples/HelloWorldAsync/Properties/AssemblyInfo.cs
+++ b/Brighter/Examples/HelloWorldAsync/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("HelloWorldAsync")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("HelloWorldAsync")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("d7d027c1-8c8b-4334-a695-7b0d139b44cd")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Brighter/Examples/HelloWorldAsync/packages.config
+++ b/Brighter/Examples/HelloWorldAsync/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+</packages>

--- a/Brighter/Paramore.CommandProcessor.sln
+++ b/Brighter/Paramore.CommandProcessor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{235DE1F1-E71B-4817-8E27-3B34FF006E4C}"
 EndProject
@@ -59,6 +59,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "paramore.brighter.commandprocessor.messaginggateway.azureservicebus", "paramore.brighter.commandprocessor.messaginggateway.azureservicebus\paramore.brighter.commandprocessor.messaginggateway.azureservicebus.csproj", "{E70C6C98-E292-4919-B72A-8F2D42E9E6CC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskList.AzureServiceBus", "Examples\TaskList.AzureServiceBus\TaskList.AzureServiceBus.csproj", "{44116EA2-4ABF-47CF-81E5-2B312390CDB8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloWorldAsync", "Examples\HelloWorldAsync\HelloWorldAsync.csproj", "{D7D027C1-8C8B-4334-A695-7B0D139B44CD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -310,6 +312,18 @@ Global
 		{44116EA2-4ABF-47CF-81E5-2B312390CDB8}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{44116EA2-4ABF-47CF-81E5-2B312390CDB8}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{44116EA2-4ABF-47CF-81E5-2B312390CDB8}.Release|x86.ActiveCfg = Release|Any CPU
+		{D7D027C1-8C8B-4334-A695-7B0D139B44CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7D027C1-8C8B-4334-A695-7B0D139B44CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7D027C1-8C8B-4334-A695-7B0D139B44CD}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{D7D027C1-8C8B-4334-A695-7B0D139B44CD}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{D7D027C1-8C8B-4334-A695-7B0D139B44CD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D7D027C1-8C8B-4334-A695-7B0D139B44CD}.Debug|x86.Build.0 = Debug|Any CPU
+		{D7D027C1-8C8B-4334-A695-7B0D139B44CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7D027C1-8C8B-4334-A695-7B0D139B44CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7D027C1-8C8B-4334-A695-7B0D139B44CD}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{D7D027C1-8C8B-4334-A695-7B0D139B44CD}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{D7D027C1-8C8B-4334-A695-7B0D139B44CD}.Release|x86.ActiveCfg = Release|Any CPU
+		{D7D027C1-8C8B-4334-A695-7B0D139B44CD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -328,5 +342,6 @@ Global
 		{EF185CD6-C3A6-452F-8143-CD35F93AEB22} = {235DE1F1-E71B-4817-8E27-3B34FF006E4C}
 		{CAE808DF-01DB-4411-B66A-73C6F1DCF7AA} = {235DE1F1-E71B-4817-8E27-3B34FF006E4C}
 		{44116EA2-4ABF-47CF-81E5-2B312390CDB8} = {235DE1F1-E71B-4817-8E27-3B34FF006E4C}
+		{D7D027C1-8C8B-4334-A695-7B0D139B44CD} = {235DE1F1-E71B-4817-8E27-3B34FF006E4C}
 	EndGlobalSection
 EndGlobal

--- a/Brighter/paramore.brighter.commandprocessor.tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/MessageDispatch/TestDoubles/SpyCommandProcessor.cs
@@ -24,6 +24,7 @@ THE SOFTWARE. */
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using paramore.brighter.commandprocessor;
 using paramore.brighter.commandprocessor.actions;
 
@@ -33,7 +34,8 @@ namespace paramore.commandprocessor.tests.MessageDispatch.TestDoubles
     {
         Send,
         Publish,
-        Post
+        Post,
+        SendAsync
     }
 
     internal class SpyCommandProcessor : IAmACommandProcessor
@@ -51,6 +53,19 @@ namespace paramore.commandprocessor.tests.MessageDispatch.TestDoubles
         {
             _requests.Enqueue(command);
             _commands.Add(CommandType.Send);
+        }
+
+        /// <summary>
+        /// Awaitably sends the specified command.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="command">The command.</param>
+        /// <returns>awaitable <see cref="Task"/>.</returns>
+        public virtual async Task SendAsync<T>(T command) where T : class, IRequest
+        {
+            _requests.Enqueue(command);
+            _commands.Add(CommandType.SendAsync);
+            await Task.Delay(0);
         }
 
         /// <summary>

--- a/Brighter/paramore.brighter.commandprocessor/AsyncHandlerFactory.cs
+++ b/Brighter/paramore.brighter.commandprocessor/AsyncHandlerFactory.cs
@@ -1,0 +1,82 @@
+﻿// ***********************************************************************
+// Assembly         : paramore.brighter.commandprocessor
+// Author           : Fred
+// Created          : 2015-12-21
+//                    Based on HandlerFactory
+//
+// Last Modified By : Fred
+// Last Modified On : 2015-12-21
+// ***********************************************************************
+//     Copyright (c) . All rights reserved.
+// </copyright>
+// <summary></summary>
+// ***********************************************************************
+
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+
+namespace paramore.brighter.commandprocessor
+{
+    /// <summary>
+    /// Class AsyncHandlerFactory
+    /// </summary>
+    /// <typeparam name="TRequest">The type of the t request.</typeparam>
+    internal class AsyncHandlerFactory<TRequest> where TRequest : class, IRequest
+    {
+        private readonly AsyncRequestHandlerAttribute _attribute;
+        private readonly IAmAnAsyncHandlerFactory _factory;
+        private readonly Type _messageType;
+        private readonly IRequestContext _requestContext;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncHandlerFactory{TRequest}"/> class.
+        /// </summary>
+        /// <param name="attribute">The attribute.</param>
+        /// <param name="factory">The async handler factory.</param>
+        /// <param name="requestContext">The request context.</param>
+        public AsyncHandlerFactory(AsyncRequestHandlerAttribute attribute, IAmAnAsyncHandlerFactory factory, IRequestContext requestContext)
+        {
+            _attribute = attribute;
+            _factory = factory;
+            _requestContext = requestContext;
+            _messageType = typeof(TRequest);
+        }
+
+        /// <summary>
+        /// Creates the async request handler.
+        /// </summary>
+        /// <returns><see cref="IHandleRequestsAsync{TRequest}"/>.</returns>
+        public IHandleRequestsAsync<TRequest> CreateAsyncRequestHandler()
+        {
+            var handlerType = _attribute.GetHandlerType().MakeGenericType(_messageType);
+            var handler = (IHandleRequestsAsync<TRequest>)_factory.Create(handlerType);
+            //Lod the context befor the initializer - in case we want to use the context from within the initializer
+            handler.Context = _requestContext;
+            handler.InitializeFromAttributeParams(_attribute.InitializerParams());
+            return handler;
+        }
+    }
+}

--- a/Brighter/paramore.brighter.commandprocessor/AsyncPipelines.cs
+++ b/Brighter/paramore.brighter.commandprocessor/AsyncPipelines.cs
@@ -1,10 +1,11 @@
 ﻿// ***********************************************************************
 // Assembly         : paramore.brighter.commandprocessor
-// Author           : ian
-// Created          : 07-02-2014
+// Author           : Fred
+// Created          : 2015-12-21
+//                    Based on Pipelines.cs
 //
-// Last Modified By : ian
-// Last Modified On : 07-10-2014
+// Last Modified By : Fred
+// Last Modified On : 2015-12-21
 // ***********************************************************************
 //     Copyright (c) . All rights reserved.
 // </copyright>
@@ -35,27 +36,28 @@ THE SOFTWARE. */
 
 #endregion
 
-using System;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace paramore.brighter.commandprocessor
 {
-    /// <summary>
-    /// Interface IAmALifetime
-    /// Used to manage the lifetime of objects created for the request handling pipeline
-    /// <see cref="LifetimeScope"/> for default implementation.
-    /// </summary>
-    public interface IAmALifetime : IDisposable
+    internal class AsyncPipelines<TRequest> : IEnumerable<IHandleRequestsAsync<TRequest>> where TRequest : class, IRequest
     {
-        /// <summary>
-        /// Adds the specified instance.
-        /// </summary>
-        /// <param name="instance">The instance.</param>
-        void Add(IHandleRequests instance);
+        private readonly List<IHandleRequestsAsync<TRequest>> _filters = new List<IHandleRequestsAsync<TRequest>>();
 
-        /// <summary>
-        /// Adds the specified instance of an async handler.
-        /// </summary>
-        /// <param name="instance">The instance.</param>
-        void Add(IHandleRequestsAsync instance);
+        public IEnumerator<IHandleRequestsAsync<TRequest>> GetEnumerator()
+        {
+            return _filters.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public void Add(IHandleRequestsAsync<TRequest> handler)
+        {
+            _filters.Add(handler);
+        }
     }
 }

--- a/Brighter/paramore.brighter.commandprocessor/AsyncRequestHandler.cs
+++ b/Brighter/paramore.brighter.commandprocessor/AsyncRequestHandler.cs
@@ -1,0 +1,183 @@
+﻿// ***********************************************************************
+// Assembly         : paramore.brighter.commandprocessor
+// Author           : ian
+// Created          : 2015-12-21
+//                    Based on RequestHandler.cs
+//
+// Last Modified By : Fred
+// Last Modified On : 2015-12-21
+//                    Based on RequestHandler
+// ***********************************************************************
+//     Copyright (c) . All rights reserved.
+// </copyright>
+// <summary></summary>
+// ***********************************************************************
+
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using paramore.brighter.commandprocessor.Logging;
+
+namespace paramore.brighter.commandprocessor
+{
+    public abstract class AsyncRequestHandler<TRequest> : IHandleRequestsAsync<TRequest> where TRequest : class, IRequest
+    {
+        /// <summary>
+        /// The logger
+        /// </summary>
+        protected readonly ILog logger;
+        private IHandleRequestsAsync<TRequest> _successor;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncRequestHandler{TRequest}"/> class.
+        /// </summary>
+        protected AsyncRequestHandler() 
+            : this(LogProvider.GetCurrentClassLogger())
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncRequestHandler{TRequest}"/> class.
+        /// Generally you can should prefer the default constructor, and we will grab the logger from your log provider rather than take a direct dependency.
+        /// This can be helpful for testing.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        protected AsyncRequestHandler(ILog logger)
+        {
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Gets or sets the context.
+        /// </summary>
+        /// <value>The context.</value>
+        public IRequestContext Context { get; set; }
+
+        /// <summary>
+        /// Gets the name.
+        /// </summary>
+        /// <value>The name.</value>
+        public HandlerName Name
+        {
+            get { return new HandlerName(GetType().Name); }
+        }
+
+        /// <summary>
+        /// Sets the successor.
+        /// </summary>
+        /// <param name="successor">The successor.</param>
+        public void SetSuccessor(IHandleRequestsAsync<TRequest> successor)
+        {
+            _successor = successor;
+        }
+
+        /// <summary>
+        /// Adds to lifetime.
+        /// </summary>
+        /// <param name="instanceScope">The instance scope.</param>
+        public void AddToLifetime(IAmALifetime instanceScope)
+        {
+            instanceScope.Add(this);
+
+            if (_successor != null)
+                _successor.AddToLifetime(instanceScope);
+        }
+
+        /// <summary>
+        /// Describes the path.
+        /// </summary>
+        /// <param name="pathExplorer">The path explorer.</param>
+        public void DescribePath(IAmAPipelineTracer pathExplorer)
+        {
+            pathExplorer.AddToPath(Name);
+            if (_successor != null)
+                _successor.DescribePath(pathExplorer);
+        }
+
+        /// <summary>
+        /// Awaitably handles the specified command.
+        /// </summary>
+        /// <param name="command">The command.</param>
+        /// <returns>Awaitable <see cref="Task{TRequest}"/>.</returns>
+        public virtual async Task<TRequest> HandleAsync(TRequest command)
+        {
+            if (_successor != null)
+            {
+                logger.DebugFormat("Passing request from {0} to {1}", Name, _successor.Name);
+                return await _successor.HandleAsync(command);
+            }
+
+            return command;
+        }
+
+        /// <summary>
+        /// If a request cannot be completed by <see cref="HandleAsync"/>, implementing the <see cref="FallbackAsync"/> method provides an alternate code path that can be used
+        /// This allows for graceful  degradation. Using the <see cref="FallbackPolicyAttribute"/> handler you can configure a policy to catch either all <see cref="Exception"/>'s or
+        /// just <see cref="BrokenCircuitException"/> that occur later in the pipeline, and then call the <see cref="FallbackAsync"/> path.
+        /// Note that the <see cref="FallbackPolicyAttribute"/> target handler might be 'beginning of chain' and need to pass through to actual handler that is end of chain.
+        /// Because of this we need to call Fallback on the chain. Later step handlers don't know the context of failure so they cannot know if any operations they had, 
+        /// that could fail (such as DB access) were the cause of the failure chain being hit.
+        /// Steps that don't know how to handle should pass through.
+        /// Useful alternatives for Fallback are to try via the cache.
+        /// Note that a Fallback handler implementation should not catch exceptions in the <see cref="FallbackAsync"/> chain to avoid an infinite loop.
+        /// Call <see cref="Successor"/>.<see cref="HandleAsync"/> if having provided a Fallback you want the chain to return to the 'happy' path. Excerise caution here though
+        /// as you do not know who generated the exception that caused the fallback chain.
+        /// For this reason, the <see cref="FallbackPolicyHandler"/> puts the exception in the request context.
+        /// When the <see cref="FallbackPolicyAttribute"/> is set on the <see cref="HandleAsync"/> method of a derived class
+        /// The <see cref="FallbackPolicyHandler{TRequest}"/> will catch either all failures (backstop) or <see cref="BrokenCircuitException"/> depending on configuration
+        /// and call the <see cref="RequestHandler{TRequest}"/>'s <see cref="FallbackAsync"/> method
+        /// </summary>
+        /// <param name="command">The command.</param>
+        /// <returns>Awaitable <see cref="Task{TRequest}"/>.</returns>
+        public virtual async Task<TRequest> FallbackAsync(TRequest command)
+        {
+            if (_successor != null)
+            {
+                logger.DebugFormat("Falling back from {0} to {1}", Name, _successor.Name);
+                return await _successor.FallbackAsync(command);
+            }
+            return command;
+        }
+
+        //default is just to do nothing - use this if you need to pass data from an attribute into a handler
+        /// <summary>
+        /// Initializes from attribute parameters.
+        /// </summary>
+        /// <param name="initializerList">The initializer list.</param>
+        public virtual void InitializeFromAttributeParams(params object[] initializerList) { }
+
+
+        internal MethodInfo FindHandlerMethod()
+        {
+            var methods = GetType().GetMethods();
+            return methods
+                .Where(method => method.Name == "HandleAsync")
+                .Where(method => method.GetParameters().Count() == 1 && method.GetParameters().Single().ParameterType == typeof(TRequest))
+                .SingleOrDefault();
+        }
+
+    }
+}

--- a/Brighter/paramore.brighter.commandprocessor/AsyncRequestHandlerAttribute.cs
+++ b/Brighter/paramore.brighter.commandprocessor/AsyncRequestHandlerAttribute.cs
@@ -1,0 +1,106 @@
+﻿// ***********************************************************************
+// Assembly         : paramore.brighter.commandprocessor
+// Author           : Fred
+// Created          : 2015-12-21
+//                    Based on Pipelines.cs
+//
+// Last Modified By : Fred
+// Last Modified On : 2015-12-21
+// ***********************************************************************
+//     Copyright (c) . All rights reserved.
+// </copyright>
+// <summary></summary>
+// ***********************************************************************
+
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System;
+
+namespace paramore.brighter.commandprocessor
+{
+    /// <summary>
+    /// Class AsyncRequestHandlerAttribute.
+    /// To satisfy orthogonal concerns it is possible to create a pipeline of awaitable <see cref="IHandleRequestsAsync"/> handlers. The 'target' handler should handle the domain
+    /// logic, the other handlers in the pipeline should handle Quality of Service concerns or similar orthogonal concerns. We use an approach of attributing the <see cref="IHandleRequestsAsync{T}.HandleAsync"/>
+    /// method to indicate the other handlers in the pipeline that handle orthogonal concerns. This approach is preferred over fluent-pipeline configuration
+    /// because it allows you to easily see orthogonal concerns within the context of the target handler. In this sense Brighter is 'opinionated' about approach.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public abstract class AsyncRequestHandlerAttribute : Attribute
+    {
+        private readonly int _step;
+
+        private readonly HandlerTiming _timing;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncRequestHandlerAttribute"/> class.
+        /// </summary>
+        /// <param name="step">The step.</param>
+        /// <param name="timing">The timing.</param>
+        protected AsyncRequestHandlerAttribute(int step, HandlerTiming timing = HandlerTiming.Before)
+        {
+            _step = step;
+            _timing = timing;
+        }
+
+        //We use this to pass params from the attribute into the instance of the handler
+        //if you need to pass additional params to your handler, use this
+        /// <summary>
+        /// Initializers the parameters.
+        /// </summary>
+        /// <returns>System.Object[].</returns>
+        public virtual object[] InitializerParams()
+        {
+            return new object[0];
+        }
+
+        //In which order should we run this, within the pre or post sequence for the main target?
+        /// <summary>
+        /// Gets the step.
+        /// </summary>
+        /// <value>The step.</value>
+        public int Step
+        {
+            get { return _step; }
+        }
+
+        //Should we run this before or after the main target?
+        /// <summary>
+        /// Gets the timing.
+        /// </summary>
+        /// <value>The timing.</value>
+        public HandlerTiming Timing
+        {
+            get { return _timing; }
+        }
+
+        //What type do we implement for the Filter in the Command Processor Pipeline
+        /// <summary>
+        /// Gets the type of the handler.
+        /// </summary>
+        /// <returns>Type.</returns>
+        public abstract Type GetHandlerType();
+    }
+}

--- a/Brighter/paramore.brighter.commandprocessor/AsyncRequestHandlers.cs
+++ b/Brighter/paramore.brighter.commandprocessor/AsyncRequestHandlers.cs
@@ -1,11 +1,13 @@
 ﻿// ***********************************************************************
 // Assembly         : paramore.brighter.commandprocessor
-// Author           : ian
-// Created          : 07-02-2014
+// Author           : Fred
+// Created          : 2015-12-21
+//                    Based on RequestHandlers.cs
 //
-// Last Modified By : ian
-// Last Modified On : 07-10-2014
+// Last Modified By : Fred
+// Last Modified On : 2015-12-21
 // ***********************************************************************
+// <copyright file="Pipelines.cs" company="">
 //     Copyright (c) . All rights reserved.
 // </copyright>
 // <summary></summary>
@@ -35,27 +37,30 @@ THE SOFTWARE. */
 
 #endregion
 
-using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace paramore.brighter.commandprocessor
 {
-    /// <summary>
-    /// Interface IAmALifetime
-    /// Used to manage the lifetime of objects created for the request handling pipeline
-    /// <see cref="LifetimeScope"/> for default implementation.
-    /// </summary>
-    public interface IAmALifetime : IDisposable
+    internal class AsyncRequestHandlers<TRequest> : IEnumerable<AsyncRequestHandler<TRequest>>
+        where TRequest : class, IRequest
     {
-        /// <summary>
-        /// Adds the specified instance.
-        /// </summary>
-        /// <param name="instance">The instance.</param>
-        void Add(IHandleRequests instance);
+        private readonly IEnumerable<object> _handlers;
 
-        /// <summary>
-        /// Adds the specified instance of an async handler.
-        /// </summary>
-        /// <param name="instance">The instance.</param>
-        void Add(IHandleRequestsAsync instance);
+        internal AsyncRequestHandlers(IEnumerable<object> handlers)
+        {
+            _handlers = handlers;
+        }
+
+        public IEnumerator<AsyncRequestHandler<TRequest>> GetEnumerator()
+        {
+            return _handlers.Cast<AsyncRequestHandler<TRequest>>().GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
     }
 }

--- a/Brighter/paramore.brighter.commandprocessor/CommandProcessorBuilder.cs
+++ b/Brighter/paramore.brighter.commandprocessor/CommandProcessorBuilder.cs
@@ -92,13 +92,13 @@ namespace paramore.brighter.commandprocessor
     /// </summary>
     public class CommandProcessorBuilder : INeedAHandlers, INeedPolicy, INeedMessaging, INeedARequestContext, IAmACommandProcessorBuilder
     {
-        private ILog _logger;
         private IAmAMessageStore<Message> _messageStore;
         private IAmAMessageProducer _messagingGateway;
         private IAmAMessageMapperRegistry _messageMapperRegistry;
         private IAmARequestContextFactory _requestContextFactory;
         private IAmASubscriberRegistry _registry;
         private IAmAHandlerFactory _handlerFactory;
+        private IAmAnAsyncHandlerFactory _asyncHandlerFactory;
         private IAmAPolicyRegistry _policyRegistry;
         private int _messageStoreWriteTimeout;
         private int _messagingGatewaySendTimeout;
@@ -127,6 +127,7 @@ namespace paramore.brighter.commandprocessor
         {
             _registry = handlerConfiguration.SubscriberRegistry;
             _handlerFactory = handlerConfiguration.HandlerFactory;
+            _asyncHandlerFactory = handlerConfiguration.AsyncHandlerFactory;
             return this;
         }
 
@@ -213,6 +214,7 @@ namespace paramore.brighter.commandprocessor
                     
                     subscriberRegistry: _registry,
                     handlerFactory: _handlerFactory,
+                    asyncHandlerFactory: _asyncHandlerFactory,
                     requestContextFactory: _requestContextFactory,
                     policyRegistry: _policyRegistry);
             }

--- a/Brighter/paramore.brighter.commandprocessor/HandlerConfiguration.cs
+++ b/Brighter/paramore.brighter.commandprocessor/HandlerConfiguration.cs
@@ -52,6 +52,11 @@ namespace paramore.brighter.commandprocessor
         /// </summary>
         /// <value>The handler factory.</value>
         public IAmAHandlerFactory HandlerFactory { get; private set; }
+        /// <summary>
+        /// Gets the async handler factory.
+        /// </summary>
+        /// <value>The handler factory.</value>
+        public IAmAnAsyncHandlerFactory AsyncHandlerFactory { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HandlerConfiguration"/> class.
@@ -65,6 +70,36 @@ namespace paramore.brighter.commandprocessor
         {
             SubscriberRegistry = subscriberRegistry;
             HandlerFactory = handlerFactory;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HandlerConfiguration"/> class.
+        /// We use the <see cref="IAmASubscriberRegistry"/> instance to look up subscribers for messages when dispatching. Use <see cref="SubscriberRegistry"/> unless
+        /// you have some reason to override. We expect a <see cref="CommandProcessor.Send{T}(T)"/> to have one registered handler
+        /// We use the 
+        /// </summary>
+        /// <param name="subscriberRegistry">The subscriber registry.</param>
+        /// <param name="asyncHandlerFactory">The async handler factory.</param>
+        public HandlerConfiguration(IAmASubscriberRegistry subscriberRegistry, IAmAnAsyncHandlerFactory asyncHandlerFactory)
+        {
+            SubscriberRegistry = subscriberRegistry;
+            AsyncHandlerFactory = asyncHandlerFactory;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HandlerConfiguration"/> class.
+        /// We use the <see cref="IAmASubscriberRegistry"/> instance to look up subscribers for messages when dispatching. Use <see cref="SubscriberRegistry"/> unless
+        /// you have some reason to override. We expect a <see cref="CommandProcessor.Send{T}(T)"/> to have one registered handler
+        /// We use the 
+        /// </summary>
+        /// <param name="subscriberRegistry">The subscriber registry.</param>
+        /// <param name="handlerFactory">The handler factory.</param>
+        /// <param name="asyncHandlerFactory">The async handler factory.</param>
+        public HandlerConfiguration(IAmASubscriberRegistry subscriberRegistry, IAmAHandlerFactory handlerFactory, IAmAnAsyncHandlerFactory asyncHandlerFactory)
+        {
+            SubscriberRegistry = subscriberRegistry;
+            HandlerFactory = handlerFactory;
+            AsyncHandlerFactory = asyncHandlerFactory;
         }
 
         /// <summary>

--- a/Brighter/paramore.brighter.commandprocessor/IAmACommandProcessor.cs
+++ b/Brighter/paramore.brighter.commandprocessor/IAmACommandProcessor.cs
@@ -35,7 +35,7 @@ THE SOFTWARE. */
 
 #endregion
 
-using System;
+using System.Threading.Tasks;
 
 namespace paramore.brighter.commandprocessor
 {
@@ -55,6 +55,14 @@ namespace paramore.brighter.commandprocessor
         /// <typeparam name="T"></typeparam>
         /// <param name="command">The command.</param>
         void Send<T>(T command) where T : class, IRequest;
+
+        /// <summary>
+        /// Awaitably sends the specified command.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="command">The command.</param>
+        /// <returns>awaitable <see cref="Task"/>.</returns>
+        Task SendAsync<T>(T command) where T : class, IRequest;
 
         /// <summary>
         /// Publishes the specified event. Throws an aggregate exception on failure of a pipeline but executes remaining

--- a/Brighter/paramore.brighter.commandprocessor/IAmAnAsyncHandlerFactory.cs
+++ b/Brighter/paramore.brighter.commandprocessor/IAmAnAsyncHandlerFactory.cs
@@ -1,10 +1,11 @@
 ﻿// ***********************************************************************
 // Assembly         : paramore.brighter.commandprocessor
-// Author           : ian
-// Created          : 07-02-2014
+// Author           : Fred
+// Created          : 2015-12-21
+//                    Based on IAnAHandlerFactory.cs
 //
-// Last Modified By : ian
-// Last Modified On : 07-10-2014
+// Last Modified By : Fred
+// Last Modified On : 2015-12-21
 // ***********************************************************************
 //     Copyright (c) . All rights reserved.
 // </copyright>
@@ -40,22 +41,24 @@ using System;
 namespace paramore.brighter.commandprocessor
 {
     /// <summary>
-    /// Interface IAmALifetime
-    /// Used to manage the lifetime of objects created for the request handling pipeline
-    /// <see cref="LifetimeScope"/> for default implementation.
+    /// Interface IAmAnAysyncHandlerFactory
+    /// We do not know how to create instances of <see cref="IHandleRequestsAsync"/> implemented by your application, but need to create instances to instantiate a pipeline.
+    /// To achieve this we require clients of the Paramore.Brighter.CommandProcessor library need to implement <see cref="IAmAnAsyncHandlerFactory"/> to provide 
+    /// instances of their <see cref="IHandleRequestsAsync"/> types. You need to provide a Handler Factory to support all <see cref="IHandleRequestsAsync"/> registered 
+    /// with <see cref="IAmASubscriberRegistry"/>. Typically you would use an IoC container to implement the Handler Factory.
     /// </summary>
-    public interface IAmALifetime : IDisposable
+    public interface IAmAnAsyncHandlerFactory
     {
         /// <summary>
-        /// Adds the specified instance.
+        /// Creates the specified async handler type.
         /// </summary>
-        /// <param name="instance">The instance.</param>
-        void Add(IHandleRequests instance);
-
+        /// <param name="handlerType">Type of the handler.</param>
+        /// <returns>IHandleRequestsAsync.</returns>
+        IHandleRequestsAsync Create(Type handlerType);
         /// <summary>
-        /// Adds the specified instance of an async handler.
+        /// Releases the specified async handler.
         /// </summary>
-        /// <param name="instance">The instance.</param>
-        void Add(IHandleRequestsAsync instance);
+        /// <param name="handler">The handler.</param>
+        void Release(IHandleRequestsAsync handler);
     }
 }

--- a/Brighter/paramore.brighter.commandprocessor/IHandleRequestsAsync.cs
+++ b/Brighter/paramore.brighter.commandprocessor/IHandleRequestsAsync.cs
@@ -1,0 +1,122 @@
+// ***********************************************************************
+// Assembly         : paramore.brighter.commandprocessor
+// Author           : Fred
+// Created          : 2015-12-21
+//                    Bases on IHandleRequests
+//
+// Last Modified By : Fred
+// Last Modified On : 2015-12-21
+// ***********************************************************************
+//     Copyright (c) . All rights reserved.
+// </copyright>
+// <summary></summary>
+// ***********************************************************************
+
+#region Licence
+/* The MIT License (MIT)
+Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+
+using System.Threading.Tasks;
+
+namespace paramore.brighter.commandprocessor
+{
+    /// <summary>
+    /// Interface IHandleRequests
+    /// A target of the <see cref="CommandProcessor"/> either as the target of the Command Dispatcher to provide the domain logic required to handle the <see cref="Command"/>
+    /// or <see cref="Event"/> or as an orthogonal handler used as part of the Command Processor pipeline.
+    /// We recommend deriving your concrete handler from <see cref="AsyncRequestHandler{T}"/> instead of implementing the interface as it provides boilerplate
+    /// code for calling the next handler in sequence in the pipeline and describing the path
+    /// The <see cref="IHandleRequestsAsync"/> interface contains a contract not dependant on the <see cref="IRequest"/> and is useful when you need to deal with a handler
+    /// without knowing the specific <see cref="IRequest"/> type, but most implementations should use <see cref="IHandleRequestsAsync{T}"/> directly
+    /// </summary>
+    public interface IHandleRequestsAsync
+    {
+        /// <summary>
+        /// Gets or sets the context. Usually the context is given to you by the pipeline and you do not need to set this
+        /// </summary>
+        /// <value>The context.</value>
+        IRequestContext Context { get; set; }
+        /// <summary>
+        /// Describes the path. To support pipeline tracing. Generally return the name of this handler to <see cref="IAmAPipelineTracer"/>,
+        ///  or other information to determine the path a request will take
+        /// </summary>
+        /// <param name="pathExplorer">The path explorer.</param>
+        void DescribePath(IAmAPipelineTracer pathExplorer);
+        /// <summary>
+        /// Initializes from the <see cref="RequestHandlerAttribute"/> attribute parameters. Use when you need to provide parameter information from the
+        /// attribute to the handler. Note that the attribute implementation might include types other than primitives that you intend to pass across, but
+        /// the attribute itself can only use primitives.
+        /// You couple the handler to a specific attribute using this as you need to know about the parameters passed, so this is really only appropriate
+        /// for an attribute-handler pair used to provide orthogonal QoS to the pipeline.
+        /// </summary>
+        /// <param name="initializerList">The initializer list.</param>
+        void InitializeFromAttributeParams(params object[] initializerList);
+        /// <summary>
+        /// Gets the name of the Handler. Useful for diagnostic purposes
+        /// </summary>
+        /// <value>The name.</value>
+        HandlerName Name { get; }
+
+        /// <summary>
+        /// Adds to lifetime so that the pipeline can manage destroying handlers created as part of the pipeline by calling the client provided <see cref="IAmAHandlerFactory"/> .
+        /// </summary>
+        /// <param name="instanceScope">The instance scope.</param>
+        void AddToLifetime(IAmALifetime instanceScope);
+    }
+
+    /// <summary>
+    /// Interface IHandleRequests
+    /// A target of the <see cref="CommandProcessor"/> either as the target of the Command Dispatcher to provide the domain logic required to handle the <see cref="Command"/>
+    /// or <see cref="Event"/> or as an orthogonal handler used as part of the Command Processor pipeline.
+    /// We recommend deriving your concrete handler from <see cref="AsyncRequestHandler{T}"/> instead of implementing the interface as it provides boilerplate
+    /// code for calling the next handler in sequence in the pipeline and describing the path.
+    /// It derives from <see cref="IHandleRequestsAsync"/> which provides functionality that is not dependant on <see cref="IRequest"/>. This simplifies some tasks that do not know
+    /// the specific type of the <see cref="IRequest"/>
+    /// Implementors should use on class to implement both <see cref="IHandleRequestsAsync{T}"/> and <see cref="IHandleRequestsAsync"/> as per <see cref="AsyncRequestHandler{T}"/>
+    /// </summary>
+    /// <typeparam name="TRequest">The type of the t request.</typeparam>
+    public interface IHandleRequestsAsync<TRequest> : IHandleRequestsAsync where TRequest : class, IRequest
+    {
+        /// <summary>
+        /// Handles the specified command.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <returns>Awaitable <see cref="Task{TRequest}"/>.</returns>
+        Task<TRequest> HandleAsync(TRequest request);
+
+
+        /// <summary>
+        /// If a request cannot be completed by <see cref="HandleAsync"/>, implementing the <see cref="FallbackAsync"/> method provides an alternate code path that can be used
+        /// This allows for graceful  degradation.  
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <returns>Awaitable <see cref="Task{TRequest}"/>.</returns>
+        Task<TRequest> FallbackAsync(TRequest request);
+
+        /// <summary>
+        /// Sets the successor.
+        /// </summary>
+        /// <param name="successor">The successor.</param>
+        void SetSuccessor(IHandleRequestsAsync<TRequest> successor);
+    }
+}

--- a/Brighter/paramore.brighter.commandprocessor/Interpreter.cs
+++ b/Brighter/paramore.brighter.commandprocessor/Interpreter.cs
@@ -52,6 +52,7 @@ namespace paramore.brighter.commandprocessor
     {
         private readonly IAmASubscriberRegistry _registry;
         private readonly IAmAHandlerFactory _handlerFactory;
+        private readonly IAmAnAsyncHandlerFactory _asyncHandlerFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Interpreter{TRequest}"/> class.
@@ -59,9 +60,29 @@ namespace paramore.brighter.commandprocessor
         /// <param name="registry">The registry.</param>
         /// <param name="handlerFactory">The handler factory.</param>
         internal Interpreter(IAmASubscriberRegistry registry, IAmAHandlerFactory handlerFactory)
+            : this(registry, handlerFactory, null)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Interpreter{TRequest}"/> class.
+        /// </summary>
+        /// <param name="registry">The registry.</param>
+        /// <param name="asyncHandlerFactory">The async handler factory.</param>
+        internal Interpreter(IAmASubscriberRegistry registry, IAmAnAsyncHandlerFactory asyncHandlerFactory)
+            : this(registry, null, asyncHandlerFactory)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Interpreter{TRequest}"/> class.
+        /// </summary>
+        /// <param name="registry">The registry.</param>
+        /// <param name="handlerFactory">The handler factory.</param>
+        /// <param name="asyncHandlerFactory">The async handler factory.</param>
+        internal Interpreter(IAmASubscriberRegistry registry, IAmAHandlerFactory handlerFactory, IAmAnAsyncHandlerFactory asyncHandlerFactory)
         {
             _registry = registry;
             _handlerFactory = handlerFactory;
+            _asyncHandlerFactory = asyncHandlerFactory;
         }
 
         /// <summary>
@@ -71,7 +92,23 @@ namespace paramore.brighter.commandprocessor
         /// <returns>IEnumerable&lt;RequestHandler&lt;TRequest&gt;&gt;.</returns>
         internal IEnumerable<RequestHandler<TRequest>> GetHandlers(Type requestType)
         {
-            return new RequestHandlers<TRequest>(_registry.Get<TRequest>().Select(handlerType => _handlerFactory.Create(handlerType)).Cast<IHandleRequests<TRequest>>());
+            return new RequestHandlers<TRequest>(
+                _registry.Get<TRequest>()
+                    .Select(handlerType => _handlerFactory.Create(handlerType))
+                    .Cast<IHandleRequests<TRequest>>());
+        }
+
+        /// <summary>
+        /// Gets the async handlers.
+        /// </summary>
+        /// <param name="requestType">Type of the request.</param>
+        /// <returns><see cref="IEnumerable{AsyncRequestHandler}"/>.</returns>
+        internal IEnumerable<AsyncRequestHandler<TRequest>> GetAsyncHandlers(Type requestType)
+        {
+            return new AsyncRequestHandlers<TRequest>(
+                _registry.Get<TRequest>()
+                    .Select(handlerType => _asyncHandlerFactory.Create(handlerType))
+                    .Cast<IHandleRequestsAsync<TRequest>>());
         }
     }
 }

--- a/Brighter/paramore.brighter.commandprocessor/LifetimeScope.cs
+++ b/Brighter/paramore.brighter.commandprocessor/LifetimeScope.cs
@@ -36,6 +36,7 @@ THE SOFTWARE. */
 
 #endregion
 
+using System;
 using System.Collections.Generic;
 using paramore.brighter.commandprocessor.extensions;
 using paramore.brighter.commandprocessor.Logging;
@@ -47,27 +48,49 @@ namespace paramore.brighter.commandprocessor
         private readonly IAmAHandlerFactory _handlerFactory;
         private readonly ILog _logger;
         private readonly List<IHandleRequests> _trackedObjects = new List<IHandleRequests>();
+        private readonly List<IHandleRequestsAsync> _trackedAsyncObjects = new List<IHandleRequestsAsync>();
+        private readonly IAmAnAsyncHandlerFactory _asyncHandlerFactory;
 
         public LifetimeScope(IAmAHandlerFactory handlerFactory) 
-            :this(handlerFactory, LogProvider.GetCurrentClassLogger())
+            :this(handlerFactory, null, LogProvider.GetCurrentClassLogger())
         {}
 
-        public LifetimeScope(IAmAHandlerFactory handlerFactory, ILog logger)
+        public LifetimeScope(IAmAnAsyncHandlerFactory asyncHandlerFactory) 
+            :this(null, asyncHandlerFactory, LogProvider.GetCurrentClassLogger())
+        {}
+
+        public LifetimeScope(IAmAHandlerFactory handlerFactory, IAmAnAsyncHandlerFactory asyncHandlerFactory) 
+            :this(handlerFactory, asyncHandlerFactory, LogProvider.GetCurrentClassLogger())
+        {}
+
+        public LifetimeScope(IAmAHandlerFactory handlerFactory, IAmAnAsyncHandlerFactory asyncHandlerFactory, ILog logger)
         {
             _handlerFactory = handlerFactory;
+            _asyncHandlerFactory = asyncHandlerFactory;
             _logger = logger;
         }
 
         public int TrackedItemCount
         {
-            get { return _trackedObjects.Count; }
+            get { return _trackedObjects.Count + _trackedAsyncObjects.Count; }
         }
 
         public void Add(IHandleRequests instance)
         {
+            if (_handlerFactory == null)
+                throw new ArgumentException("An instance of a handler can not be added without a HandlerFactory.");
             _trackedObjects.Add(instance);
             if (_logger != null)
                 _logger.DebugFormat("Tracking instance {0} of type {1}", instance.GetHashCode(), instance.GetType());
+        }
+
+        public void Add(IHandleRequestsAsync instance)
+        {
+            if (_asyncHandlerFactory == null)
+                throw new ArgumentException("An instance of an async handler can not be added without an AsyncHandlerFactory.");
+            _trackedAsyncObjects.Add(instance);
+            if (_logger != null)
+                _logger.DebugFormat("Tracking async handler instance {0} of type {1}", instance.GetHashCode(), instance.GetType());
         }
 
         public void Dispose()
@@ -80,8 +103,17 @@ namespace paramore.brighter.commandprocessor
                     _logger.DebugFormat("Releasing handler instance {0} of type {1}", trackedItem.GetHashCode(), trackedItem.GetType());
             });
 
+            _trackedAsyncObjects.Each(trackedItem =>
+            {
+                //free disposable items
+                _asyncHandlerFactory.Release(trackedItem);
+                if (_logger != null)
+                    _logger.DebugFormat("Releasing async handler instance {0} of type {1}", trackedItem.GetHashCode(), trackedItem.GetType());
+            });
+
             //clear our tracking
             _trackedObjects.Clear();
+            _trackedAsyncObjects.Clear();
         }
     }
 }

--- a/Brighter/paramore.brighter.commandprocessor/PipelineBuilder.cs
+++ b/Brighter/paramore.brighter.commandprocessor/PipelineBuilder.cs
@@ -49,6 +49,7 @@ namespace paramore.brighter.commandprocessor
         private readonly ILog _logger;
         private readonly Interpreter<TRequest> _interpreter;
         private readonly IAmALifetime _instanceScope;
+        private readonly IAmAnAsyncHandlerFactory _asyncHandlerFactory;
 
         internal PipelineBuilder(IAmASubscriberRegistry registry, IAmAHandlerFactory handlerFactory) 
             :this(registry, handlerFactory, LogProvider.GetCurrentClassLogger())
@@ -61,6 +62,18 @@ namespace paramore.brighter.commandprocessor
             _logger = logger;
             _instanceScope = new LifetimeScope(handlerFactory);
             _interpreter = new Interpreter<TRequest>(registry, handlerFactory);
+        }
+
+        internal PipelineBuilder(IAmASubscriberRegistry registry, IAmAnAsyncHandlerFactory asyncHandlerFactory)
+            : this(registry, asyncHandlerFactory, LogProvider.GetCurrentClassLogger())
+        { }
+
+        public PipelineBuilder(IAmASubscriberRegistry registry, IAmAnAsyncHandlerFactory asyncHandlerFactory, ILog logger)
+        {
+            _asyncHandlerFactory = asyncHandlerFactory;
+            _logger = logger;
+            _instanceScope = new LifetimeScope(asyncHandlerFactory);
+            _interpreter = new Interpreter<TRequest>(registry, asyncHandlerFactory);
         }
 
         public Pipelines<TRequest> Build(IRequestContext requestContext)
@@ -125,7 +138,71 @@ namespace paramore.brighter.commandprocessor
             return lastInPipeline;
         }
 
+        public AsyncPipelines<TRequest> BuildAsync(IRequestContext requestContext)
+        {
+            var handlers = _interpreter.GetAsyncHandlers(typeof(TRequest));
+
+            var pipelines = new AsyncPipelines<TRequest>();
+            handlers.Each(handler => pipelines.Add(BuildAsyncPipeline(handler, requestContext)));
+
+            pipelines.Each(handler => handler.AddToLifetime(_instanceScope));
+
+            return pipelines;
+        }
+
+        private IHandleRequestsAsync<TRequest> BuildAsyncPipeline(AsyncRequestHandler<TRequest> implicitHandler, IRequestContext requestContext)
+        {
+            implicitHandler.Context = requestContext;
+
+            var preAttributes =
+                implicitHandler.FindHandlerMethod()
+                .GetOtherAsyncHandlersInPipeline()
+                .Where(attribute => attribute.Timing == HandlerTiming.Before)
+                .OrderByDescending(attribute => attribute.Step);
+
+            var firstInPipeline = PushOntoAsyncPipeline(preAttributes, implicitHandler, requestContext);
+
+            var postAttributes =
+                implicitHandler.FindHandlerMethod()
+                .GetOtherAsyncHandlersInPipeline()
+                .Where(attribute => attribute.Timing == HandlerTiming.After)
+                .OrderByDescending(attribute => attribute.Step);
+
+            AppendToAsyncPipeline(postAttributes, implicitHandler, requestContext);
+            _logger.DebugFormat("New async handler pipeline created: {0}", TracePipeline(firstInPipeline));
+            return firstInPipeline;
+        }
+
+        private void AppendToAsyncPipeline(IEnumerable<AsyncRequestHandlerAttribute> attributes, IHandleRequestsAsync<TRequest> implicitHandler, IRequestContext requestContext)
+        {
+            IHandleRequestsAsync<TRequest> lastInPipeline = implicitHandler;
+            attributes.Each(attribute =>
+            {
+                var decorator = new AsyncHandlerFactory<TRequest>(attribute, _asyncHandlerFactory, requestContext).CreateAsyncRequestHandler();
+                lastInPipeline.SetSuccessor(decorator);
+                lastInPipeline = decorator;
+            });
+        }
+
+        private IHandleRequestsAsync<TRequest> PushOntoAsyncPipeline(IEnumerable<AsyncRequestHandlerAttribute> attributes, IHandleRequestsAsync<TRequest> lastInPipeline, IRequestContext requestContext)
+        {
+            attributes.Each(attribute =>
+            {
+                var decorator = new AsyncHandlerFactory<TRequest>(attribute, _asyncHandlerFactory, requestContext).CreateAsyncRequestHandler();
+                decorator.SetSuccessor(lastInPipeline);
+                lastInPipeline = decorator;
+            });
+            return lastInPipeline;
+        }
+
         private PipelineTracer TracePipeline(IHandleRequests<TRequest> firstInPipeline)
+        {
+            var pipelineTracer = new PipelineTracer();
+            firstInPipeline.DescribePath(pipelineTracer);
+            return pipelineTracer;
+        }
+
+        private PipelineTracer TracePipeline(IHandleRequestsAsync<TRequest> firstInPipeline)
         {
             var pipelineTracer = new PipelineTracer();
             firstInPipeline.DescribePath(pipelineTracer);

--- a/Brighter/paramore.brighter.commandprocessor/SubscriberRegistry.cs
+++ b/Brighter/paramore.brighter.commandprocessor/SubscriberRegistry.cs
@@ -72,6 +72,16 @@ namespace paramore.brighter.commandprocessor
             Add(typeof(TRequest), typeof(TImplementation));
         }
 
+        /// <summary>
+        /// Registers this instance.
+        /// </summary>
+        /// <typeparam name="TRequest">The type of the t request.</typeparam>
+        /// <typeparam name="TImplementation">The type of the t implementation.</typeparam>
+        public void RegisterAsync<TRequest, TImplementation>() where TRequest : class, IRequest where TImplementation : class, IHandleRequestsAsync<TRequest>
+        {
+            Add(typeof(TRequest), typeof(TImplementation));
+        }
+
         public void Add(Type requestType, Type handlerType)
         {
             var observed = _observers.ContainsKey(requestType);

--- a/Brighter/paramore.brighter.commandprocessor/extensions/ReflectionExtensions.cs
+++ b/Brighter/paramore.brighter.commandprocessor/extensions/ReflectionExtensions.cs
@@ -40,5 +40,15 @@ namespace paramore.brighter.commandprocessor.extensions
                      .Cast<RequestHandlerAttribute>()
                      .ToList();
         }
+
+        internal static IEnumerable<AsyncRequestHandlerAttribute> GetOtherAsyncHandlersInPipeline(this MethodInfo targetMethod)
+        {
+            var customAttributes = targetMethod.GetCustomAttributes(true);
+            return customAttributes
+                     .Select(attr => (Attribute)attr)
+                     .Where(a => a.GetType().GetTypeInfo().BaseType == typeof(AsyncRequestHandlerAttribute))
+                     .Cast<AsyncRequestHandlerAttribute>()
+                     .ToList();
+        }
     }
 }

--- a/Brighter/paramore.brighter.commandprocessor/paramore.brighter.commandprocessor.csproj
+++ b/Brighter/paramore.brighter.commandprocessor/paramore.brighter.commandprocessor.csproj
@@ -50,6 +50,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Packages\LibLog.4.2\LibLog.cs" />
+    <Compile Include="AsyncHandlerFactory.cs" />
+    <Compile Include="AsyncPipelines.cs" />
+    <Compile Include="AsyncRequestHandler.cs" />
+    <Compile Include="AsyncRequestHandlerAttribute.cs" />
+    <Compile Include="AsyncRequestHandlers.cs" />
     <Compile Include="ChannelName.cs" />
     <Compile Include="Clock.cs" />
     <Compile Include="CommandProcessorBuilder.cs" />
@@ -81,6 +86,8 @@
     <Compile Include="IAmAMessageProducer.cs" />
     <Compile Include="IAmAMessageConsumer.cs" />
     <Compile Include="IEvent.cs" />
+    <Compile Include="IHandleRequestsAsync.cs" />
+    <Compile Include="IAmAnAsyncHandlerFactory.cs" />
     <Compile Include="InMemoryCommandStore.cs" />
     <Compile Include="logging\Attributes\RequestLoggingAttribute.cs" />
     <Compile Include="logging\Handlers\RequestLoggingHandler.cs" />


### PR DESCRIPTION
Enable the use of async/await with the in-line (synchronous) processing of a command.

Extend the IAmACommandProcessor interface with "Task SendAsync(T command) where T : class, IRequest;". And add the interface IHandleRequestsAsync to be implemented by the async request handler.

Extend the framework to support the registration of async handler factories, subscription by async handlers and various other required plumbing;