### PR TITLE
await and publish async events sequentially

### DIFF
--- a/Brighter/paramore.brighter.commandprocessor/CommandProcessor.cs
+++ b/Brighter/paramore.brighter.commandprocessor/CommandProcessor.cs
@@ -640,25 +640,22 @@ namespace paramore.brighter.commandprocessor
                 
                 _logger.InfoFormat("Found {0} async pipelines for event: {1} {2}", handlerCount, @event.GetType(), @event.Id);
 
-                var eventTasks = handlerChain.Select(handleRequests => handleRequests.HandleAsync(@event, ct)).Cast<Task>().ToList();
-
-                // Whenall will aggregate individual exceptions, and await will raise it when all tasks have completed
-                try
+                var exceptions = new List<Exception>();
+                foreach (var handler in handlerChain)
                 {
-                    await Task.WhenAll(eventTasks).ConfigureAwait(continueOnCapturedContext: false);
-                }
-                catch (Exception)
-                {
-                    var exceptions = new List<Exception>();
-                    foreach (var task in eventTasks.Where(task => task.IsFaulted))
+                    try
                     {
-                        if (task.Exception != null) exceptions.AddRange(task.Exception.InnerExceptions);
-                        else exceptions.Add(task.Exception);
+                        await handler.HandleAsync(@event, ct);
                     }
+                    catch (Exception e)
+                    {
+                        exceptions.Add(e);
+                    }
+                }
+                if (exceptions.Count > 0)
                     throw new AggregateException(
                         "Failed to async publish to one more handlers successfully, see inner exceptions for details",
                         exceptions);
-                }
             }
         }
 


### PR DESCRIPTION
await and publish async events sequentially to avoid race conditions caused by parallel execution.