### PR TITLE
Increase log level for "stopping receiving messages from queue" log...

### DIFF
--- a/Brighter/paramore.brighter.serviceactivator/MessagePump.cs
+++ b/Brighter/paramore.brighter.serviceactivator/MessagePump.cs
@@ -172,7 +172,7 @@ namespace paramore.brighter.serviceactivator
                 }
                 catch (ConfigurationException configurationException)
                 {
-                    if (Logger != null) Logger.DebugException("MessagePump: Stopping receiving of messages from {1} on thread # {0}", configurationException, Thread.CurrentThread.ManagedThreadId, Channel.Name);
+                    if (Logger != null) Logger.ErrorException("MessagePump: Stopping receiving of messages from {1} on thread # {0}", configurationException, Thread.CurrentThread.ManagedThreadId, Channel.Name);
 
                     RejectMessage(message);
                     Channel.Dispose();
@@ -275,7 +275,7 @@ namespace paramore.brighter.serviceactivator
 
                 if (exception is ConfigurationException)
                 {
-                    if (Logger != null) Logger.DebugException("MessagePump: Stopping receiving of messages from {1} on thread # {0}", exception, Thread.CurrentThread.ManagedThreadId, Channel.Name);
+                    if (Logger != null) Logger.ErrorException("MessagePump: Stopping receiving of messages from {1} on thread # {0}", exception, Thread.CurrentThread.ManagedThreadId, Channel.Name);
                     stop = true;
                     break;
                 }
@@ -294,7 +294,7 @@ namespace paramore.brighter.serviceactivator
 
         private void RejectMessage(Message message)
         {
-            if (Logger != null) Logger.DebugFormat("MessagePump: Rejecting message {0} from {2} on thread # {1}", message.Id, Thread.CurrentThread.ManagedThreadId, Channel.Name);
+            if (Logger != null) Logger.InfoFormat("MessagePump: Rejecting message {0} from {2} on thread # {1}", message.Id, Thread.CurrentThread.ManagedThreadId, Channel.Name);
 
             Channel.Reject(message);
         }


### PR DESCRIPTION
...message from DEBUG to ERROR and increase log level for reject message to INFO.

Brighter now stops receiving messages from a queue where the message type doesn't match the request type. Which is great, but it's a breaking change.
Log level of DEBUG seems inappropriate when this happens, because people are likely to have that level filtered out.

Example:

```
MessagePump: Stopping receiving of messages from [redacted] on thread # 13
paramore.brighter.commandprocessor.ConfigurationException: Message cf44c25c-3c46-490e-8672-b85f4fa055bb mismatch. Message type is 'MT_COMMAND' yet mapper produced message of type IEvent
   at paramore.brighter.serviceactivator.MessagePump`1.DispatchRequest(MessageHeader messageHeader, TRequest request)
   at paramore.brighter.serviceactivator.MessagePump`1.Run()
```