### PR TITLE
support all types supported by rabbit in message headers instead of just strings

### DIFF
--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/HeaderNames.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/HeaderNames.cs
@@ -52,6 +52,10 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
         /// </summary>
         public const string MESSAGE_ID = "MessageId";
         /// <summary>
+        /// The correlation id
+        /// </summary>
+        public const string CORRELATION_ID = "CorrelationId";
+        /// <summary>
         /// The topic{CC2D43FA-BBC4-448A-9D0B-7B57ADF2655C}
         /// </summary>
         public const string TOPIC = "Topic";
@@ -72,7 +76,7 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
         /// </summary>
         public const string ORIGINAL_MESSAGE_ID = Message.OriginalMessageIdHeaderName;
         /// <summary>
-        /// Tag used to identify this message in the sequence against it's Id (used to perform multiple ack against Id upto Tag).
+        /// Tag used to identify this message in the sequence against its Id (used to perform multiple ack against Id upto Tag).
         /// </summary>
         public const string DELIVERY_TAG = Message.DeliveryTagHeaderName;
     }

--- a/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/RmqMessageCreator.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messaginggateway.rmq/RmqMessageCreator.cs
@@ -105,7 +105,7 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
                         timeStamp.Success ? new MessageHeader(messageId.Result, topic.Result, messageType.Result, timeStamp.Result, handledCount.Result, delayedMilliseconds.Result) : new MessageHeader(messageId.Result, topic.Result, messageType.Result),
                         new MessageBody(body));
 
-                    headers.Each(header => message.Header.Bag.Add(header.Key, Encoding.UTF8.GetString((byte[])header.Value)));
+                    headers.Each(header => message.Header.Bag.Add(header.Key, ParseHeaderValue(header.Value)));
                 }
             }
             catch (Exception e)
@@ -213,6 +213,12 @@ namespace paramore.brighter.commandprocessor.messaginggateway.rmq
 
             _logger.DebugFormat("Could not parse message MessageId, new message id is {0}", Guid.Empty);
             return new HeaderResult<Guid>(Guid.Empty, false);
+        }
+
+        private static object ParseHeaderValue(object value)
+        {
+            var bytes = value as byte[];
+            return bytes != null ? Encoding.UTF8.GetString(bytes) : value;
         }
     }
 }


### PR DESCRIPTION
Currently, when a message header contains anything other than a byte[], the message consumer will blow up because the message creator tries to convert all header values into an utf-8 string.
The rabbit mq client supports more types than strings, (like int, long, double, bool and null), so this change will only convert to string if the value is byte[], otherwise just use the value.