### PR TITLE
Fix SqlMessageStore duplicate-key checking

### DIFF
--- a/Brighter/paramore.brighter.commandprocessor.messagestore.mssql/MsSqlMessageStore.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messagestore.mssql/MsSqlMessageStore.cs
@@ -56,7 +56,7 @@ namespace paramore.brighter.commandprocessor.messagestore.mssql
     public class MsSqlMessageStore : IAmAMessageStore<Message>, IAmAMessageStoreAsync<Message>,
         IAmAMessageStoreViewer<Message>, IAmAMessageStoreViewerAsync<Message>
     {
-        private const int MsSqlDuplicateKeyError = 2601;
+        private const int MsSqlDuplicateKeyError = 2627;
         private const int SqlCeDuplicateKeyError = 25016;
         private readonly MsSqlMessageStoreConfiguration _configuration;
         private readonly JavaScriptSerializer _javaScriptSerializer;

--- a/Brighter/paramore.brighter.commandprocessor.messagestore.mssql/MsSqlMessageStore.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messagestore.mssql/MsSqlMessageStore.cs
@@ -56,7 +56,8 @@ namespace paramore.brighter.commandprocessor.messagestore.mssql
     public class MsSqlMessageStore : IAmAMessageStore<Message>, IAmAMessageStoreAsync<Message>,
         IAmAMessageStoreViewer<Message>, IAmAMessageStoreViewerAsync<Message>
     {
-        private const int DuplicateKeyError = -1;
+        private const int MsSqlDuplicateKeyError = 2601;
+        private const int SqlCeDuplicateKeyError = 25016;
         private readonly MsSqlMessageStoreConfiguration _configuration;
         private readonly JavaScriptSerializer _javaScriptSerializer;
         private readonly ILog _log;
@@ -66,8 +67,7 @@ namespace paramore.brighter.commandprocessor.messagestore.mssql
         /// </summary>
         /// <param name="configuration">The configuration.</param>
         public MsSqlMessageStore(MsSqlMessageStoreConfiguration configuration)
-            : this(configuration, LogProvider.GetCurrentClassLogger())
-        { }
+            : this(configuration, LogProvider.GetCurrentClassLogger()) {}
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="MsSqlMessageStore" /> class.
@@ -98,37 +98,33 @@ namespace paramore.brighter.commandprocessor.messagestore.mssql
                 connection.Open();
                 var command = InitAddDbCommand(connection, parameters);
 
-                int result;
-
-                if (this._configuration.Type == MsSqlMessageStoreConfiguration.DatabaseType.SqlCe)
+                try
                 {
-                    var existsCommand = InitExistsDbCommand(connection, message.Id);
-                    result = (int)existsCommand.ExecuteScalar() != 0 ? DuplicateKeyError : 0;
-
-                    if (result != -1)
+                    command.ExecuteNonQuery();
+                }
+                catch (SqlException sqlException)
+                {
+                    if (sqlException.Number == MsSqlDuplicateKeyError)
                     {
-                        result = (int)command.ExecuteNonQuery();
+                        _log.WarnFormat(
+                            "MsSqlMessageStore: A duplicate Message with the MessageId {0} was inserted into the Message Store, ignoring and continuing",
+                            message.Id);
+                        return;
                     }
-                }
-                else
-                {
-                    result = (int)command.ExecuteScalar();
-                }
 
-                if (result == DuplicateKeyError)
-                {
-                    _log.WarnFormat(
-                        "MsSqlMessageStore: {1} duplicate Message with the MessageId {0} was inserted into the Message Store, ignoring and continuing",
-                        message.Id,
-                        this._configuration.Type == MsSqlMessageStoreConfiguration.DatabaseType.SqlCe ? "[SQLServerCe ERROR] !!DO NOT USE SQLCE IN PRODUCTION!! Having to assume" : "A");
+                    throw;
                 }
-                else if (result < 1)
+                catch (SqlCeException sqlCeException)
                 {
-                    var errorResult = string.Format("MySqlMessageStore: Message store reported 0 affected rows when attempting to insert MessageId {0} into the Message Store.", message.Id);
+                    if (sqlCeException.NativeError == SqlCeDuplicateKeyError)
+                    {
+                        _log.WarnFormat(
+                            "MsSqlMessageStore: A duplicate Message with the MessageId {0} was inserted into the Message Store, ignoring and continuing",
+                            message.Id);
+                        return;
+                    }
 
-                    _log.Error(errorResult);
-
-                    throw new Exception(errorResult);
+                    throw;
                 }
             }
         }
@@ -159,38 +155,35 @@ namespace paramore.brighter.commandprocessor.messagestore.mssql
                 await connection.OpenAsync(ct ?? CancellationToken.None).ConfigureAwait(ContinueOnCapturedContext);
                 var command = InitAddDbCommand(connection, parameters);
 
-                CancellationToken token = ct ?? CancellationToken.None;
-                int result;
-
-                if (this._configuration.Type == MsSqlMessageStoreConfiguration.DatabaseType.SqlCe)
+                try
                 {
-                    var existsCommand = InitExistsDbCommand(connection, message.Id);
-                    result = (int)await existsCommand.ExecuteScalarAsync(token) != 0 ? DuplicateKeyError : 0;
-
-                    if (result != -1)
+                    await
+                        command.ExecuteNonQueryAsync(ct ?? CancellationToken.None)
+                            .ConfigureAwait(ContinueOnCapturedContext);
+                }
+                catch (SqlException sqlException)
+                {
+                    if (sqlException.Number == MsSqlDuplicateKeyError)
                     {
-                        result = (int)await command.ExecuteNonQueryAsync(token).ConfigureAwait(ContinueOnCapturedContext);
+                        _log.WarnFormat(
+                            "MsSqlMessageStore: A duplicate Message with the MessageId {0} was inserted into the Message Store, ignoring and continuing",
+                            message.Id);
+                        return;
                     }
-                }
-                else
-                {
-                    result = (int)await command.ExecuteScalarAsync(token).ConfigureAwait(ContinueOnCapturedContext);
-                }
 
-                if (result == DuplicateKeyError)
-                {
-                    _log.WarnFormat(
-                        "MsSqlMessageStore: {1} duplicate Message with the MessageId {0} was inserted into the Message Store, ignoring and continuing",
-                        message.Id,
-                        this._configuration.Type == MsSqlMessageStoreConfiguration.DatabaseType.SqlCe ? "[SQLServerCe ERROR] !!DO NOT USE SQLCE IN PRODUCTION!! Having to assume" : "A");
+                    throw;
                 }
-                else if (result < 1)
+                catch (SqlCeException sqlCeException)
                 {
-                    var errorResult = string.Format("MySqlMessageStore: Message store reported 0 affected rows when attempting to insert MessageId {0} into the Message Store.", message.Id);
+                    if (sqlCeException.NativeError == SqlCeDuplicateKeyError)
+                    {
+                        _log.WarnFormat(
+                            "MsSqlMessageStore: A duplicate Message with the MessageId {0} was inserted into the Message Store, ignoring and continuing",
+                            message.Id);
+                        return;
+                    }
 
-                    _log.Error(errorResult);
-
-                    throw new Exception(errorResult);
+                    throw;
                 }
             }
         }
@@ -270,7 +263,7 @@ namespace paramore.brighter.commandprocessor.messagestore.mssql
         /// <param name="pageSize">Number of messages to return in search results (default = 100)</param>
         /// <param name="pageNumber">Page number of results to return (default = 1)</param>
         /// <returns></returns>
-        public async Task<IList<Message>> GetAsync(int pageSize = 100, int pageNumber = 1, CancellationToken? ct = null)
+        public async Task<IList<Message>> GetAsync(int pageSize = 100, int pageNumber = 1,CancellationToken? ct = null)
         {
             using (var connection = GetConnection())
             using (var command = connection.CreateCommand())
@@ -351,30 +344,13 @@ namespace paramore.brighter.commandprocessor.messagestore.mssql
             return null;
         }
 
-        private DbCommand InitExistsDbCommand(DbConnection connection, Guid messageId)
-        {
-            // TODO: Delete this when SqlServerCe support is removed.
-            var command = connection.CreateCommand();
-            command.CommandText = string.Format("SELECT COUNT(*) FROM {0} WHERE MessageId = @MessageId", this._configuration.MessageStoreTableName);
-            command.Parameters.Add(CreateSqlParameter("MessageId", messageId));
-            return command;
-        }
-
         private DbCommand InitAddDbCommand(DbConnection connection, DbParameter[] parameters)
         {
             var command = connection.CreateCommand();
-
-            // TODO: SqlServerCe should support "INSERT INTO .. SELECT .. WHERE NOT EXISTS (..) but doesn't work,
-            // TODO: as such we can't make this operation atomic so we have to assume every error is a duplicate :(
-            var sql = this._configuration.Type != MsSqlMessageStoreConfiguration.DatabaseType.SqlCe 
-                ? string.Format(
-@"IF EXISTS (SELECT * FROM {0} WHERE MessageId = @MessageId)
-RETURN {1}
-INSERT INTO {0} (MessageId, MessageType, Topic, Timestamp, HeaderBag, Body) VALUES (@MessageId, @MessageType, @Topic, @Timestamp, @HeaderBag, @Body)
-RETURN @@ROWCOUNT", _configuration.MessageStoreTableName, DuplicateKeyError)
-                : string.Format(
-@"INSERT INTO {0} (MessageId, MessageType, Topic, Timestamp, HeaderBag, Body) VALUES (@MessageId, @MessageType, @Topic, @Timestamp, @HeaderBag, @Body)", this._configuration.MessageStoreTableName);
-
+            var sql =
+                string.Format(
+                    "INSERT INTO {0} (MessageId, MessageType, Topic, Timestamp, HeaderBag, Body) VALUES (@MessageId, @MessageType, @Topic, @Timestamp, @HeaderBag, @Body)",
+                    _configuration.MessageStoreTableName);
             command.CommandText = sql;
             command.Parameters.AddRange(parameters);
             return command;
@@ -390,7 +366,7 @@ RETURN @@ROWCOUNT", _configuration.MessageStoreTableName, DuplicateKeyError)
                 CreateSqlParameter("Topic", message.Header.Topic),
                 CreateSqlParameter("Timestamp", message.Header.TimeStamp),
                 CreateSqlParameter("HeaderBag", bagJson),
-                CreateSqlParameter("Body", message.Body.Value),
+                CreateSqlParameter("Body", message.Body.Value)
             };
             return parameters;
         }
@@ -398,7 +374,7 @@ RETURN @@ROWCOUNT", _configuration.MessageStoreTableName, DuplicateKeyError)
         private Message MapAMessage(IDataReader dr)
         {
             var id = dr.GetGuid(dr.GetOrdinal("MessageId"));
-            var messageType = (MessageType)Enum.Parse(typeof(MessageType), dr.GetString(dr.GetOrdinal("MessageType")));
+            var messageType = (MessageType) Enum.Parse(typeof (MessageType), dr.GetString(dr.GetOrdinal("MessageType")));
             var topic = dr.GetString(dr.GetOrdinal("Topic"));
 
             var header = new MessageHeader(id, topic, messageType);

--- a/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_The_Message_Is_Already_In_The_Message_Store.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_The_Message_Is_Already_In_The_Message_Store.cs
@@ -34,7 +34,6 @@ using paramore.brighter.commandprocessor.messagestore.mssql;
 namespace paramore.commandprocessor.tests.MessageStore.MsSql
 {
     [Subject(typeof(MsSqlMessageStore))]
-    [Tags("MessageStoreTests")]
     public class When_The_Message_Is_Already_In_The_Message_Store
     {
         private const string ConnectionString = "DataSource=\"" + TestDbPath + "\"";

--- a/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_The_Message_Is_Already_In_The_Message_Store_Async.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_The_Message_Is_Already_In_The_Message_Store_Async.cs
@@ -35,7 +35,6 @@ using paramore.brighter.commandprocessor.messagestore.mssql;
 namespace paramore.commandprocessor.tests.MessageStore.MsSql
 {
     [Subject(typeof(MsSqlMessageStore))]
-    [Tags("MessageStoreTests")]
     public class When_The_Message_Is_Already_In_The_Message_Store_Async
     {
         private const string ConnectionString = "DataSource=\"" + TestDbPath + "\"";

--- a/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_There_Are_Multiple_Messages_In_The_Message_Store_And_A_Range_Is_Fetched.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_There_Are_Multiple_Messages_In_The_Message_Store_And_A_Range_Is_Fetched.cs
@@ -36,7 +36,6 @@ using paramore.brighter.commandprocessor.messagestore.mssql;
 namespace paramore.commandprocessor.tests.MessageStore.MsSql
 {
     [Subject(typeof(MsSqlMessageStore))]
-    [Tags("MessageStoreTests")]
     public class When_There_Are_Multiple_Messages_In_The_Message_Store_And_A_Range_Is_Fetched
     {
         private const string ConnectionString = "DataSource=\"" + TestDbPath + "\"";

--- a/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_There_Are_Multiple_Messages_In_The_Message_Store_And_A_Range_Is_Fetched_Async.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_There_Are_Multiple_Messages_In_The_Message_Store_And_A_Range_Is_Fetched_Async.cs
@@ -37,7 +37,6 @@ using paramore.brighter.commandprocessor.messagestore.mssql;
 namespace paramore.commandprocessor.tests.MessageStore.MsSql
 {
     [Subject(typeof(MsSqlMessageStore))]
-    [Tags("MessageStoreTests")]
     public class When_There_Are_Multiple_Messages_In_The_Message_Store_And_A_Range_Is_Fetched_Async
     {
         private const string ConnectionString = "DataSource=\"" + TestDbPath + "\"";

--- a/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_There_Is_No_Message_In_The_Sql_Message_Store.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_There_Is_No_Message_In_The_Sql_Message_Store.cs
@@ -34,7 +34,6 @@ using paramore.brighter.commandprocessor.messagestore.mssql;
 namespace paramore.commandprocessor.tests.MessageStore.MsSql
 {
     [Subject(typeof(MsSqlMessageStore))]
-    [Tags("MessageStoreTests")]
     public class When_There_Is_No_Message_In_The_Sql_Message_Store
     {
         private const string ConnectionString = "DataSource=\"" + TestDbPath + "\"";

--- a/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_There_Is_No_Message_In_The_Sql_Message_Store_Async.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_There_Is_No_Message_In_The_Sql_Message_Store_Async.cs
@@ -35,7 +35,6 @@ using paramore.brighter.commandprocessor.messagestore.mssql;
 namespace paramore.commandprocessor.tests.MessageStore.MsSql
 {
     [Subject(typeof(MsSqlMessageStore))]
-    [Tags("MessageStoreTests")]
     public class When_There_Is_No_Message_In_The_Sql_Message_Store_Async
     {
         private const string ConnectionString = "DataSource=\"" + TestDbPath + "\"";

--- a/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_Writing_A_Message_To_The_Message_Store.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_Writing_A_Message_To_The_Message_Store.cs
@@ -34,7 +34,6 @@ using paramore.brighter.commandprocessor.messagestore.mssql;
 namespace paramore.commandprocessor.tests.MessageStore.MsSql
 {
     [Subject(typeof(MsSqlMessageStore))]
-    [Tags("MessageStoreTests")]
     public class When_Writing_A_Message_To_The_Message_Store
     {
         private const string ConnectionString = "DataSource=\"" + TestDbPath + "\"";

--- a/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_Writing_A_Message_To_The_Message_Store_Async.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_Writing_A_Message_To_The_Message_Store_Async.cs
@@ -34,7 +34,6 @@ using paramore.brighter.commandprocessor.messagestore.mssql;
 namespace paramore.commandprocessor.tests.MessageStore.MsSql
 {
     [Subject(typeof(MsSqlMessageStore))]
-    [Tags("MessageStoreTests")]
     public class When_Writing_A_Message_To_The_Message_Store_Async
     {
         private const string ConnectionString = "DataSource=\"" + TestDbPath + "\"";

--- a/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_Writing_Messages_To_The_Message_Store.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_Writing_Messages_To_The_Message_Store.cs
@@ -36,7 +36,6 @@ using paramore.brighter.commandprocessor.messagestore.mssql;
 namespace paramore.commandprocessor.tests.MessageStore.MsSql
 {
     [Subject(typeof(MsSqlMessageStore))]
-    [Tags("MessageStoreTests")]
     public class When_Writing_Messages_To_The_Message_Store
     {
         private const string ConnectionString = "DataSource=\"" + TestDbPath + "\"";

--- a/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_Wrting_Messages_To_The_Message_Store_Async.cs
+++ b/Brighter/paramore.brighter.commandprocessor.tests/MessageStore/MsSql/When_Wrting_Messages_To_The_Message_Store_Async.cs
@@ -37,7 +37,6 @@ using paramore.brighter.commandprocessor.messagestore.mssql;
 namespace paramore.commandprocessor.tests.MessageStore.MsSql
 {
     [Subject(typeof(MsSqlMessageStore))]
-    [Tags("MessageStoreTests")]
     public class When_Wrting_Messages_To_The_Message_Store_Async
     {
         private const string ConnectionString = "DataSource=\"" + TestDbPath + "\"";


### PR DESCRIPTION
This PR reverts the change I made some time ago as against #178 because;

(a) I stupidly used a `RETURN` statement that doesn't work with in-line SQL, only when wrapped in a `sp_executesql`
(b) The issue of Polly intercepting the duplicate-key exception not working was because the error code was wrong for a PK

**NOTE**: There will be another PR incoming that changes the MessageStore table to use an IDENTITY integer based column with `MessageId` instead having a "Unique Index". This is because we observed slow insertion times because of the physical page splits when the table becomes large. Ironically this changes the error code back to 2601. Kudos to @mehdime for spotting this! 👍 