### PR TITLE
Update SqlMessage/CommandStore Schema and unique key checks.

### DIFF
--- a/Brighter/paramore.brighter.commandprocessor.commandstore.mssql/DDL Scripts/MSSQL/CommandStore.sql
+++ b/Brighter/paramore.brighter.commandprocessor.commandstore.mssql/DDL Scripts/MSSQL/CommandStore.sql
@@ -2,12 +2,26 @@
 -- Number of tables: 1
 -- Commands: 0 row(s)
 
+PRINT 'Creating Commands table'
 CREATE TABLE [Commands] (
-  [CommandId] uniqueidentifier NOT NULL
+  [Id] [BIGINT] NOT NULL IDENTITY
+, [CommandId] uniqueidentifier NOT NULL
 , [CommandType] nvarchar(256) NULL
 , [CommandBody] ntext NULL
 , [Timestamp] datetime NULL
+, PRIMARY KEY ( [Id] )
 );
 GO
-ALTER TABLE [Commands] ADD CONSTRAINT [PK_MessageId] PRIMARY KEY ([CommandId]);
+IF (NOT EXISTS ( SELECT    *
+                  FROM      sys.indexes
+                  WHERE     name = 'UQ_Commands__CommandId'
+                            AND object_id = OBJECT_ID('Commands') )
+   )
+BEGIN
+    PRINT 'Creating a unique index on the CommandId column of the Command table...'
+
+    CREATE UNIQUE NONCLUSTERED INDEX UQ_Commands__CommandId
+    ON Commands(CommandId)
+END
 GO
+Print 'Done'

--- a/Brighter/paramore.brighter.commandprocessor.commandstore.mssql/MsSqlCommandStore.cs
+++ b/Brighter/paramore.brighter.commandprocessor.commandstore.mssql/MsSqlCommandStore.cs
@@ -54,7 +54,8 @@ namespace paramore.brighter.commandprocessor.commandstore.mssql
     /// </summary>
     public class MsSqlCommandStore : IAmACommandStore, IAmACommandStoreAsync
     {
-        private const int MsSqlDuplicateKeyError = 2601;
+        private const int MsSqlDuplicateKeyError_UniqueIndexViolation = 2601;
+        private const int MsSqlDuplicateKeyError_UniqueConstraintViolation = 2627;
         private const int SqlCeDuplicateKeyError = 25016;
         private readonly MsSqlCommandStoreConfiguration _configuration;
         private readonly ILog _log;
@@ -99,16 +100,21 @@ namespace paramore.brighter.commandprocessor.commandstore.mssql
                 }
                 catch (SqlException sqlException)
                 {
-                    if (sqlException.Number != MsSqlDuplicateKeyError) throw;
-                    _log.WarnFormat(
-                        "MsSqlMessageStore: A duplicate Message with the MessageId {0} was inserted into the Message Store, ignoring and continuing",
-                        command.Id);
+                    if (sqlException.Number == MsSqlDuplicateKeyError_UniqueIndexViolation || sqlException.Number == MsSqlDuplicateKeyError_UniqueConstraintViolation)
+                    {
+                        _log.WarnFormat(
+                            "MsSqlMessageStore: A duplicate Command with the CommandId {0} was inserted into the Message Store, ignoring and continuing",
+                            command.Id);
+                        return;
+                    }
+
+                    throw;
                 }
                 catch (SqlCeException sqlCeException)
                 {
                     if (sqlCeException.NativeError != SqlCeDuplicateKeyError) throw;
                     _log.WarnFormat(
-                        "MsSqlMessageStore: A duplicate Message with the MessageId {0} was inserted into the Message Store, ignoring and continuing",
+                        "MsSqlMessageStore: A duplicate Command with the CommandId {0} was inserted into the Message Store, ignoring and continuing",
                         command.Id);
                 }
             }
@@ -159,16 +165,21 @@ namespace paramore.brighter.commandprocessor.commandstore.mssql
                 }
                 catch (SqlException sqlException)
                 {
-                    if (sqlException.Number != MsSqlDuplicateKeyError) throw;
-                    _log.WarnFormat(
-                        "MsSqlMessageStore: A duplicate Message with the MessageId {0} was inserted into the Message Store, ignoring and continuing",
-                        command.Id);
+                    if (sqlException.Number == MsSqlDuplicateKeyError_UniqueIndexViolation || sqlException.Number == MsSqlDuplicateKeyError_UniqueConstraintViolation)
+                    {
+                        _log.WarnFormat(
+                            "MsSqlMessageStore: A duplicate Command with the CommandId {0} was inserted into the Message Store, ignoring and continuing",
+                            command.Id);
+                        return;
+                    }
+
+                    throw;
                 }
                 catch (SqlCeException sqlCeException)
                 {
                     if (sqlCeException.NativeError != SqlCeDuplicateKeyError) throw;
                     _log.WarnFormat(
-                        "MsSqlMessageStore: A duplicate Message with the MessageId {0} was inserted into the Message Store, ignoring and continuing",
+                        "MsSqlMessageStore: A duplicate Command with the CommandId {0} was inserted into the Message Store, ignoring and continuing",
                         command.Id);
                 }
             }

--- a/Brighter/paramore.brighter.commandprocessor.messagestore.mssql/DDL Scripts/MSSQL/MessageStore.sql
+++ b/Brighter/paramore.brighter.commandprocessor.messagestore.mssql/DDL Scripts/MSSQL/MessageStore.sql
@@ -2,14 +2,28 @@
 -- Number of tables: 1
 -- Messages: 0 row(s)
 
+PRINT 'Creating Messages table'
 CREATE TABLE [Messages] (
-  [MessageId] uniqueidentifier NOT NULL
+  [Id] [BIGINT] NOT NULL IDENTITY
+, [MessageId] uniqueidentifier NOT NULL
 , [Topic] nvarchar(255) NULL
 , [MessageType] nvarchar(32) NULL
 , [Timestamp] datetime NULL
 , [HeaderBag] ntext NULL
 , [Body] ntext NULL
+, PRIMARY KEY ( [Id] )
 );
 GO
-ALTER TABLE [Messages] ADD CONSTRAINT [PK_MessageId] PRIMARY KEY ([MessageId]);
+IF (NOT EXISTS ( SELECT    *
+                  FROM      sys.indexes
+                  WHERE     name = 'UQ_Messages__MessageId'
+                            AND object_id = OBJECT_ID('Messages') )
+   )
+BEGIN
+    PRINT 'Creating a unique index on the MessageId column of the Messages table...'
+
+    CREATE UNIQUE NONCLUSTERED INDEX UQ_Messages__MessageId
+    ON Messages(MessageId)
+END
 GO
+PRINT 'Done'

--- a/Brighter/paramore.brighter.commandprocessor.messagestore.mssql/MsSqlMessageStore.cs
+++ b/Brighter/paramore.brighter.commandprocessor.messagestore.mssql/MsSqlMessageStore.cs
@@ -56,7 +56,8 @@ namespace paramore.brighter.commandprocessor.messagestore.mssql
     public class MsSqlMessageStore : IAmAMessageStore<Message>, IAmAMessageStoreAsync<Message>,
         IAmAMessageStoreViewer<Message>, IAmAMessageStoreViewerAsync<Message>
     {
-        private const int MsSqlDuplicateKeyError = 2627;
+        private const int MsSqlDuplicateKeyError_UniqueIndexViolation = 2601;
+        private const int MsSqlDuplicateKeyError_UniqueConstraintViolation = 2627;
         private const int SqlCeDuplicateKeyError = 25016;
         private readonly MsSqlMessageStoreConfiguration _configuration;
         private readonly JavaScriptSerializer _javaScriptSerializer;
@@ -104,7 +105,7 @@ namespace paramore.brighter.commandprocessor.messagestore.mssql
                 }
                 catch (SqlException sqlException)
                 {
-                    if (sqlException.Number == MsSqlDuplicateKeyError)
+                    if (sqlException.Number == MsSqlDuplicateKeyError_UniqueIndexViolation || sqlException.Number == MsSqlDuplicateKeyError_UniqueConstraintViolation)
                     {
                         _log.WarnFormat(
                             "MsSqlMessageStore: A duplicate Message with the MessageId {0} was inserted into the Message Store, ignoring and continuing",
@@ -163,7 +164,7 @@ namespace paramore.brighter.commandprocessor.messagestore.mssql
                 }
                 catch (SqlException sqlException)
                 {
-                    if (sqlException.Number == MsSqlDuplicateKeyError)
+                    if (sqlException.Number == MsSqlDuplicateKeyError_UniqueIndexViolation || sqlException.Number == MsSqlDuplicateKeyError_UniqueConstraintViolation)
                     {
                         _log.WarnFormat(
                             "MsSqlMessageStore: A duplicate Message with the MessageId {0} was inserted into the Message Store, ignoring and continuing",


### PR DESCRIPTION
As noted in PR #191 we observed some slow INSERTION times because the physical page splits in the message store tables became quite large. To resolve this we added an IDENTITY integer based column with `MessageId`/`CommandId` instead having a "Unique Index". Ironically this changes the error code back to `2601` but have now updated code to check for both `2601` and `2627` to cover both schema approaches by default (in a hope to be backward compatible).